### PR TITLE
Fix expansion of MX equations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ sympy >= 0.7.6.1
 scipy >= 0.13.3
 numpy >= 1.8.2
 jinja2 >= 2.7.2
-casadi >= 3.3.0
+casadi >= 3.4.0


### PR DESCRIPTION
According to Joris Gillis (CasADi co-author), ca.matrix_expand() is
broken and will not be fixed. Instead, we will then rely on regular
.expand() functionality to turn MX into SX, without the "graceful"
fallback that ca.matrix_expand() was supposed to offer. From initial
tests, it seems that most/all commonly used functionality is supported
by .expand().