### PR TITLE
More aggressive alias checking

### DIFF
--- a/test/models/SimplifyLoop.mo
+++ b/test/models/SimplifyLoop.mo
@@ -1,13 +1,13 @@
 model SimplifyLoop
     Real x;
-    Real y[2];
+    Real y[3];
     parameter Real p3 = 0.125;
     parameter Real p2 = 2 * p3;
     parameter Real p1 = 2 * p2;
     parameter Real p = 2 * p1;
     parameter Integer n = 1;
 equation
-    for i in 1:2*n loop
+    for i in 1:3*n loop
         y[i] = p * i * x;
     end for;
 end SimplifyLoop;


### PR DESCRIPTION
If we cannot detect an alias based on the MX symbols/expression, it may
be because of nested map/if_else/etc. expressions that obscure it. To
expose remaining possible aliases, we expand the equation to SX.

Note that we still do fast checks first, e.g. on the MX graph. The
slowest operation (ca.substitute) is only used as a last resort. This
way the slowdown to the alias detection is is minimal (1.0 - 1.5x), even
for very large models with 100,000+ alias equations.

These extra checks typically result in 1-3% more aliases being detected.

The 'test_simplify_reduce_affine_expression_loop' now finds an
additional alias (x = y[1]). To be able to reliably keep testing the
'reduce affine' portion, the size of 'y' has been increased from 2 to 3.

Closes #55