### PR TITLE
Run fewer appveyor tests since it is slower than travis.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,10 @@
 # Adapted from https://packaging.python.org/en/latest/appveyor/
 
 environment:
+  # We just run 2 tests because it takes 3 min each to build
   matrix:
     - PYTHON: "C:\\Python35"
       TOX_ENV: "py35"
-    - PYTHON: "C:\\Python35-x64"
-      TOX_ENV: "py35"
-    - PYTHON: "C:\\Python36"
-      TOX_ENV: "py36"
     - PYTHON: "C:\\Python36-x64"
       TOX_ENV: "py36"
 


### PR DESCRIPTION
We are currently building up a long queue on appveyor, since it is slower than travis. Is it reasonable to only run 2 of the 4 test cases?

Appveyor was running 4 tests at 3 min each, (once for branch and once for pr), so 24 min.
Travis builds in 10 minutes on average including the wait time.

I configured appveyor to only build the pr and not the branch (appveyor/ci#882) (so it tests the version after merging with master only). This takes us down to 12 min. Then if we reduce to 2 test cases, we get to 6 min.

*Note: Sorry for all of the opening and closing, trying to get the status labels to behave.