### PR TITLE
Fix CasADi numeric equivalence test

### DIFF
--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -163,10 +163,11 @@ class GenCasadiTest(unittest.TestCase):
         zerotest__H = ca.MX.sym("zerotest.H")
         zerotest__Q = ca.MX.sym("zerotest.Q")
 
-        ref_model.alg_states = list(map(Variable, [p__H, a__down__H, b__down__H, c__down__H, c__up__H, hb__up__H, a__up__H,
-                                b__up__H, qa__down__H, a__up__Q, qa__down__Q, c__down__Q, hb__up__Q, c__up__Q, b__up__Q,
-                                b__down__Q, p__Q, a__down__Q, zerotest__H, zerotest__Q]))
-
+        ref_model.alg_states = list(map(Variable, [
+            a__up__H, a__down__H, b__up__H, b__down__H, c__up__H, c__down__H,
+            qa__down__H, p__H, hb__up__H, zerotest__H,
+            a__up__Q, a__down__Q, b__up__Q, b__down__Q, c__up__Q, c__down__Q,
+            qa__down__Q, p__Q, hb__up__Q, zerotest__Q]))
         ref_model.equations = [a__up__H - a__down__H,
                                b__up__H - b__down__H,
                                c__up__H - c__down__H,
@@ -235,10 +236,16 @@ class GenCasadiTest(unittest.TestCase):
         hb__up__Q = ca.MX.sym("hb.up.Q")
         hb__up__Z = ca.MX.sym("hb.up.Z")
 
-        ref_model.alg_states = list(map(Variable, [qc__down__H, a__down__H, b__down__H, c__down__H, c__up__H, hb__up__H, a__up__H,
-                                b__up__H, qa__down__H, a__up__Q, qa__down__Q, c__down__Q, hb__up__Q, c__up__Q, b__up__Q,
-                                b__down__Q, qc__down__Q, a__down__Q, a__up__Z, a__down__Z, b__up__Z, b__down__Z,
-                                c__up__Z, c__down__Z, d__up__H, d__up__Q, d__down__Q, d__down__H, d__down__Z, qa__down__Z, qc__down__Z, hb__up__Z]))
+        ref_model.alg_states = list(map(Variable, [
+            a__up__H, a__down__H, b__up__H, b__down__H,
+            c__up__H, c__down__H, d__up__H, d__down__H,
+            qa__down__H, qc__down__H, hb__up__H,
+            a__up__Q, a__down__Q, b__up__Q, b__down__Q,
+            c__up__Q, c__down__Q, d__up__Q, d__down__Q,
+            qa__down__Q, qc__down__Q, hb__up__Q,
+            a__up__Z, a__down__Z, b__up__Z, b__down__Z,
+            c__up__Z, c__down__Z, d__down__Z,
+            qa__down__Z, qc__down__Z, hb__up__Z]))
 
         ref_model.equations = [a__up__H - a__down__H,
                                a__up__Q + a__down__Q,
@@ -453,7 +460,7 @@ class GenCasadiTest(unittest.TestCase):
         S1 = ca.MX.sym("S1")
         S2 = ca.MX.sym("S2")
         r = ca.MX.sym("r")
-        ref_model.alg_states = list(map(Variable, [c, a, d, e, S1, S2, r]))
+        ref_model.alg_states = list(map(Variable, [r, c, a, d, e, S1, S2]))
         ref_model.outputs = list(map(Variable, [c, a, d, e, S1, S2]))
         ref_model.equations = [ca.vertcat(c, a, d, e, S1, S2) - ca.vertcat(*circle_properties.call([r])[0:-1])]
 
@@ -622,14 +629,14 @@ class GenCasadiTest(unittest.TestCase):
         x = ca.MX.sym("x", 2)
         y = ca.MX.sym("y", 2)
         z = ca.MX.sym("z", 2)
-        xt3_delayed = ca.MX.sym("_pymoca_delay_0", 2)
+        at3_delayed = ca.MX.sym("_pymoca_delay_0", 2)
         delay_time = ca.MX.sym("delay_time")
 
         ref_model.alg_states = list(map(Variable, [x, y]))
-        ref_model.inputs = list(map(Variable, [xt3_delayed, z, delay_time]))
+        ref_model.inputs = list(map(Variable, [at3_delayed, z, delay_time]))
         ref_model.inputs[-1].fixed = True
-        ref_model.equations = [ca.horzcat(x - 5 * z, y - xt3_delayed)]
-        ref_model.delay_states = [xt3_delayed]
+        ref_model.equations = [ca.horzcat(x - 5 * z, y - at3_delayed)]
+        ref_model.delay_states = [at3_delayed]
         ref_model.delay_arguments = [DelayArgument(3 * x, delay_time)]
 
         self.assert_model_equivalent_numeric(ref_model, casadi_model)
@@ -651,16 +658,16 @@ class GenCasadiTest(unittest.TestCase):
         y = _array_mx("y", 2)
         a = _array_mx("a", 2)
         z = _array_mx("z", 2)
-        xt3_delayed = _array_mx("_pymoca_delay_0", 2)
+        at3_delayed = _array_mx("_pymoca_delay_0", 2)
         delay_time = ca.MX.sym("delay_time")
 
         ref_model.alg_states = list(map(Variable, [*x, *y, *a]))
-        ref_model.inputs = list(map(Variable, [*xt3_delayed, *z, delay_time]))
+        ref_model.inputs = list(map(Variable, [*at3_delayed, *z, delay_time]))
         ref_model.inputs[-1].fixed = True
         # TODO: "a" is not yet deteced as an alias of "x" when expanding.
-        ref_model.equations = [*(x - 5 * z), *(y - xt3_delayed), *(x - a)]
-        ref_model.delay_states = [*xt3_delayed]
-        ref_model.delay_arguments = [DelayArgument(3 * x_i, delay_time) for x_i in x]
+        ref_model.equations = [*(x - 5 * z), *(y - at3_delayed), *(a - x)]
+        ref_model.delay_states = [*at3_delayed]
+        ref_model.delay_arguments = [DelayArgument(3 * a_i, delay_time) for a_i in a]
 
         self.assert_model_equivalent_numeric(ref_model, casadi_model)
 

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -53,7 +53,7 @@ class GenCasadiTest(unittest.TestCase):
 
             args_in = []
             for i in range(this.n_in()):
-                sp = this.sparsity_in(0)
+                sp = this.sparsity_in(i)
                 r = ca.DM(sp, np.random.random(sp.nnz()))
                 args_in.append(r)
 

--- a/test/models/ArrayExpressions.mo
+++ b/test/models/ArrayExpressions.mo
@@ -52,7 +52,8 @@ equation
 
     // Nesting
     nested1.z = ones(3);
-    nested2[1].z = {4, 5, 6};
+    // FIXME: We should be able to index with `nested2[1].z`, but we currently need the `[:]`.
+    nested2[1].z[:] = {4, 5, 6};
     nested2[2].z[1] = 3;
     nested2[2].z[2] = 2;
     nested2[2].z[3] = 1;


### PR DESCRIPTION
- [x] Fix now failing tests because of variable ordering
- [x] Fix usage of arrays in equations without [:] operator
- [x] Rebase to put fixes first, and this 0 -> i change last (to make sure every commit in masters succesfully builds and tests).