### PR TITLE
Reconstruct delay_arguments in load_model(), and handle delay arguments

### DIFF
--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -52,7 +52,7 @@ class ForLoop:
         self.values = np.arange(start, stop + step, step, dtype=np.int)
         self.index_variable = ca.MX.sym(i.name)
         self.name = i.name
-        self.indexed_symbols = {}
+        self.indexed_symbols = OrderedDict()
 
     def register_indexed_symbol(self, e, index_function, transpose, tree, index_expr=None):
         if isinstance(index_expr, ca.MX) and index_expr is not self.index_variable:
@@ -163,6 +163,20 @@ class Generator(TreeListener):
         if len(tree.statements) + len(tree.initial_statements) > 0:
             raise NotImplementedError('Statements are currently supported inside functions only')
 
+        # We do not support delayMax yet, so delay durations can only depend
+        # on constants, parameters and fixed inputs.
+        if self.model.delay_states:
+            delay_durations = ca.veccat(*(x.duration for x in self.model.delay_arguments))
+            disallowed_duration_symbols = ca.vertcat(self.model.time,
+                ca.veccat(*self.model._symbols(self.model.states)),
+                ca.veccat(*self.model._symbols(self.model.der_states)),
+                ca.veccat(*self.model._symbols(self.model.alg_states)),
+                ca.veccat(*(x.symbol for x in self.model.inputs if not x.fixed)))
+
+            if ca.depends_on(delay_durations, disallowed_duration_symbols):
+                raise ValueError(
+                    "Delay durations can only depend on parameters, constants and fixed inputs.")
+
         self.entered_classes.pop()
 
     def exitArray(self, tree):
@@ -251,16 +265,21 @@ class Generator(TreeListener):
         elif op == 'delay' and n_operands == 2:
             expr = self.get_mx(tree.operands[0])
             duration = self.get_mx(tree.operands[1])
-            
+
             src = ca.MX.sym('_pymoca_delay_{}'.format(self.delay_counter), *expr.size())
             self.delay_counter += 1
+
+            for f in self.for_loops:
+                syms = set(ca.symvar(expr))
+                if syms.intersection(f.indexed_symbols):
+                    f.register_indexed_symbol(src, lambda i: i, True, tree.operands[0], f.index_variable)
 
             self.model.delay_states.append(src.name())
             self.model.inputs.append(Variable(src))
 
             delay_argument = DelayArgument(expr, duration)
             self.model.delay_arguments.append(delay_argument)
-    
+
         elif op in OP_MAP and n_operands == 2:
             lhs = ca.MX(self.get_mx(tree.operands[0]))
             rhs = ca.MX(self.get_mx(tree.operands[1]))
@@ -358,7 +377,35 @@ class Generator(TreeListener):
             indexed_symbols_full = []
             for k in indexed_symbols:
                 s = f.indexed_symbols[k]
-                orig_symbol = self.nodes[self.current_class][s.tree.name]
+                try:
+                    i = self.model.delay_states.index(k.name())
+                except ValueError:
+                    orig_symbol = self.nodes[self.current_class][s.tree.name]
+                else:
+                    # We are missing a similarly shaped delayed symbol. Make a new one with the appropriate shape.
+                    delay_symbol = self.model.delay_arguments[i]
+
+                    # We need to figure out the shape of the expression that
+                    # we are delaying. The symbols that can occur in the delay
+                    # expression should have been encountered before this
+                    # iteration of the loop. The assert statement below covers
+                    # this.
+                    delay_expr_args = all_args[:len(indexed_symbols_full)+1]
+                    assert set(ca.symvar(delay_symbol.expr)).issubset(delay_expr_args)
+
+                    f_delay_expr = ca.Function('delay_expr', delay_expr_args, [delay_symbol.expr])
+                    f_delay_map = f_delay_expr.map("map", self.map_mode, len(f.values), list(
+                        range(len(args), len(all_args))), [])
+                    [res] = f_delay_map.call([f.values] + indexed_symbols_full + free_vars)
+                    res = res.T
+
+                    # Make the symbol with the appropriate size, and replace the old symbol with the new one.
+                    orig_symbol = ca.MX.sym(k.name(), *res.size())
+
+                    model_input = next(x for x in self.model.inputs if x.symbol.name() == k.name())
+                    model_input.symbol = orig_symbol
+                    self.model.delay_arguments[i] = DelayArgument(res, delay_symbol.duration)
+
                 indexed_symbol = orig_symbol[s.indices]
                 if s.transpose:
                     indexed_symbol = ca.transpose(indexed_symbol)

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -10,6 +10,7 @@ import logging
 import sys
 from collections import OrderedDict
 from typing import Union
+import os
 
 import numpy as np
 

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -283,7 +283,7 @@ class GenCasadiTest(unittest.TestCase):
         elem__tc__a = ca.MX.sym("elem.tc.a")
         b = ca.MX.sym("b")
 
-        ref_model.alg_states = map(Variable, [elem__tc__i, elem__tc__a, b])
+        ref_model.alg_states = list(map(Variable, [elem__tc__i, elem__tc__a, b]))
 
         ref_model.equations = [elem__tc__i - 1,
                                elem__tc__a - b]
@@ -502,7 +502,8 @@ class GenCasadiTest(unittest.TestCase):
         ref_model.equations = [
             ca.horzcat(x - (np.arange(1, 11) + b), w[0, :].T - np.arange(1, 11), w[1, :].T - np.arange(2, 21, 2), u - np.ones((10, 2)), v.T - np.ones((10, 2))),
             y[0:5] - np.zeros(5), y[5:] - np.ones(5),
-            ca.horzcat(z[0:5] - np.array([2, 2, 2, 2, 2]), z[5:10] - np.array([1, 1, 1, 1, 1])), der_s - np.ones(10), ca.horzcat(Arr[:, 1], Arr[:, 0]) - np.array([[2, 1], [2, 1]])]
+            ca.horzcat(z[0:5] - np.array([2, 2, 2, 2, 2]), z[5:10] - np.array([1, 1, 1, 1, 1])), der_s - np.ones(10),
+            ca.horzcat(Arr[:, 1], Arr[:, 0]) - np.array([[2, 1], [2, 1]])]
 
         self.assert_model_equivalent_numeric(ref_model, casadi_model)
 
@@ -605,6 +606,61 @@ class GenCasadiTest(unittest.TestCase):
         ref_model.equations = [y - x_delayed]
         ref_model.delay_states = [x_delayed]
         ref_model.delay_arguments = [DelayArgument(x, 6 * hour)]
+
+        self.assert_model_equivalent_numeric(ref_model, casadi_model)
+
+    def test_delay_for_loop(self):
+        with open(os.path.join(MODEL_DIR, 'DelayForLoop.mo'), 'r') as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+        casadi_model = gen_casadi.generate(ast_tree, 'DelayForLoop')
+        casadi_model.simplify({'detect_aliases': True})
+        print(casadi_model)
+
+        ref_model = Model()
+
+        x = ca.MX.sym("x", 2)
+        y = ca.MX.sym("y", 2)
+        z = ca.MX.sym("z", 2)
+        xt3_delayed = ca.MX.sym("_pymoca_delay_0", 2)
+        delay_time = ca.MX.sym("delay_time")
+
+        ref_model.alg_states = list(map(Variable, [x, y]))
+        ref_model.inputs = list(map(Variable, [xt3_delayed, z, delay_time]))
+        ref_model.inputs[-1].fixed = True
+        ref_model.equations = [ca.horzcat(x - 5 * z, y - xt3_delayed)]
+        ref_model.delay_states = [xt3_delayed]
+        ref_model.delay_arguments = [DelayArgument(3 * x, delay_time)]
+
+        self.assert_model_equivalent_numeric(ref_model, casadi_model)
+
+    def test_delay_for_loop_with_expand_vectors(self):
+        with open(os.path.join(MODEL_DIR, 'DelayForLoop.mo'), 'r') as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+        casadi_model = gen_casadi.generate(ast_tree, 'DelayForLoop')
+        casadi_model.simplify({'expand_vectors': True, 'detect_aliases': True})
+        print(casadi_model)
+
+        ref_model = Model()
+
+        def _array_mx(name, n):
+            return np.array([ca.MX.sym("{}[{}]".format(name, i)) for i in range(n)])
+
+        x = _array_mx("x", 2)
+        y = _array_mx("y", 2)
+        a = _array_mx("a", 2)
+        z = _array_mx("z", 2)
+        xt3_delayed = _array_mx("_pymoca_delay_0", 2)
+        delay_time = ca.MX.sym("delay_time")
+
+        ref_model.alg_states = list(map(Variable, [*x, *y, *a]))
+        ref_model.inputs = list(map(Variable, [*xt3_delayed, *z, delay_time]))
+        ref_model.inputs[-1].fixed = True
+        # TODO: "a" is not yet deteced as an alias of "x" when expanding.
+        ref_model.equations = [*(x - 5 * z), *(y - xt3_delayed), *(x - a)]
+        ref_model.delay_states = [*xt3_delayed]
+        ref_model.delay_arguments = [DelayArgument(3 * x_i, delay_time) for x_i in x]
 
         self.assert_model_equivalent_numeric(ref_model, casadi_model)
 
@@ -742,6 +798,26 @@ class GenCasadiTest(unittest.TestCase):
         self.assertIsInstance(cached_model, CachedModel)
 
         # Compare
+        self.assert_model_equivalent_numeric(ref_model, cached_model)
+
+    def test_cache_delay_arguments(self):
+        # Clear cache
+        db_file = os.path.join(MODEL_DIR, 'Delay')
+        try:
+            os.remove(db_file)
+        except FileNotFoundError:
+            pass
+
+        compiler_options = {'cache': True}
+
+        ref_model = transfer_model(MODEL_DIR, 'Delay', compiler_options)
+        self.assertIsInstance(ref_model, Model)
+        self.assertNotIsInstance(ref_model, CachedModel)
+
+        cached_model = transfer_model(MODEL_DIR, 'Delay', compiler_options)
+        self.assertIsInstance(cached_model, Model)
+        self.assertIsInstance(cached_model, CachedModel)
+
         self.assert_model_equivalent_numeric(ref_model, cached_model)
 
     def test_codegen(self):

--- a/test/models/DelayForLoop.mo
+++ b/test/models/DelayForLoop.mo
@@ -1,0 +1,11 @@
+model DelayForLoop
+  Real[2] x, y, a;
+  input Real z[2];
+  input Real delay_time(fixed=true);
+equation
+  for i in 1:2 loop
+    x[i] = 5 * z[i];
+    y[i] = delay(3 * a[i], delay_time);
+  end for;
+  a = x;
+end DelayForLoop;


### PR DESCRIPTION
in simplify().

- [x] Test the substitute for delay variables in simplify()
- [x] Test the writing/reading delay from cache


