### PR TITLE
Use _modelica_shape when making der, delay

### DIFF
--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -270,7 +270,11 @@ class Generator(TreeListener):
             expr = self.get_mx(tree.operands[0])
             duration = self.get_mx(tree.operands[1])
 
-            src = _new_mx('_pymoca_delay_{}'.format(self.delay_counter), *expr.size())
+            try:
+                src = _new_mx('_pymoca_delay_{}'.format(self.delay_counter), *expr._modelica_shape)
+            except AttributeError:
+                src = _new_mx('_pymoca_delay_{}'.format(self.delay_counter), *expr.size())
+
             self.delay_counter += 1
 
             for f in self.for_loops:
@@ -650,7 +654,10 @@ class Generator(TreeListener):
                     else:
                         return 0
                 else:
-                    der_s = _new_mx("der({})".format(s.name()), s.size())
+                    try:
+                        der_s = _new_mx("der({})".format(s.name()), s._modelica_shape)
+                    except AttributeError:
+                        der_s = _new_mx("der({})".format(s.name()), s.size())
                     self.derivative[s.name()] = der_s
                     self.nodes[self.current_class][der_s.name()] = der_s
                     return der_s
@@ -662,7 +669,10 @@ class Generator(TreeListener):
             slice_info = s.info()['slice']
             dep = s.dep()
             if dep.name() not in self.derivative:
-                der_dep = _new_mx("der({})".format(dep.name()), dep.size())
+                try:
+                    der_dep = _new_mx("der({})".format(dep.name()), dep._modelica_shape)
+                except AttributeError:
+                    der_dep = _new_mx("der({})".format(dep.name()), dep.size())
                 self.derivative[dep.name()] = der_dep
                 return der_dep[slice_info['start']:slice_info['stop']:slice_info['step']]
             else:


### PR DESCRIPTION
In several places in the code, we construct new symbols with the same
shape as preexisting expressions. When available, we now use the
_modelica_shape attribute to construct new symbols.