### PR TITLE
Fix expand vectors symbolic attribute error

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -366,7 +366,7 @@ class Model:
                             for attribute in CASADI_ATTRIBUTES:
                                 # Can't convert 3D arrays to MX, so we convert to nparray instead
                                 value = getattr(old_var, attribute)
-                                if not np.isscalar(value):
+                                if not isinstance(value, ca.MX) and not np.isscalar(value):
                                     value = np.array(value)
                                 else:
                                     value = ca.MX(getattr(old_var, attribute))

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -760,7 +760,8 @@ class GenCasadiTest(unittest.TestCase):
         # Alias detection results in fmin/fmax function calls in the attributes
         compiler_options = \
             {'cache': True,
-             'detect_aliases': True}
+             'detect_aliases': True,
+             'expand_vectors': True}
 
         ref_model = transfer_model(MODEL_DIR, 'ParameterAttributes', compiler_options)
         self.assertIsInstance(ref_model, Model)

--- a/test/models/ParameterAttributes.mo
+++ b/test/models/ParameterAttributes.mo
@@ -4,6 +4,7 @@ model ParameterAttributes
 	Real a(min=min_, max=10.0);
 	Real b(min=0.0,  max=max_);
 	Real c;
+	Real[3] d(each min=-max_, each max=max_);
 equation
 	a = b;
 	c = a * b;


### PR DESCRIPTION
If a state had a shape that was not (1,) and symbolic parameters in its
attribute expressions, we would attempt to cast the sybolic expression
into a numpy array, throwing an error. We now check for symbolics in the
attribute expressions as well before casting to numpy array.