### PR TITLE
Make OrderedSet pickleable and deepcopyable

### DIFF
--- a/src/pymoca/backends/casadi/alias_relation.py
+++ b/src/pymoca/backends/casadi/alias_relation.py
@@ -1,7 +1,11 @@
 from collections import OrderedDict, MutableSet
 
-# From https://code.activestate.com/recipes/576694/
 class OrderedSet(MutableSet):
+    """
+    Adapted from https://code.activestate.com/recipes/576694/
+    with some additional methods:
+    __getstate__, __setstate__, __getitem__
+    """
 
     def __init__(self, iterable=None):
         self.end = end = [] 
@@ -16,8 +20,15 @@ class OrderedSet(MutableSet):
     def __contains__(self, key):
         return key in self.map
 
+    def __getstate__(self):
+        """ Avoids max depth RecursionError when using pickle """
+        return list(self)
+
+    def __setstate__(self, state):
+        """ Tells pickle how to restore instance """
+        self.__init__(state)
+
     def __getitem__(self, index):
-        # Method added by JB
         if isinstance(index, slice):
             start, stop, stride = index.indices(len(self))
             return [self.__getitem__(i) for i in range(start, stop, stride)]


### PR DESCRIPTION
Users might want to pickle or deepcopy pymoca data structures, e.g.
AliasRelation. The linked list underlying the OrderedSet class (used by
AliasRelation and others) would produce max depth recursion errors with
the default behaviour, so we define methods __getstate__ and
__setstate__ to keep behaviour as expected.