### PR TITLE
Check symbol modification target existence

### DIFF
--- a/test/models/ModificationTypo.mo
+++ b/test/models/ModificationTypo.mo
@@ -1,0 +1,27 @@
+model B
+  Real X;
+end B;
+
+model C
+  extends B;
+end C;
+
+model D
+  C c;
+end D;
+
+model Wrong1
+  extends D(c.x(nominal=2));
+end Wrong1;
+
+model Good1
+  extends D(c.X(nominal=2));
+end Good1;
+
+model Wrong2
+  B b(x=3);
+end Wrong2;
+
+model Good2
+  B b(X=3);
+end Good2;

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -135,6 +135,19 @@ class ParseTest(unittest.TestCase):
 
         self.assertEqual(flat_tree.classes['MainModel'].symbols['e.HQ.H'].min.name, "e.H_b")
 
+    def test_modification_typo(self):
+        with open(os.path.join(MODEL_DIR, 'ModificationTypo.mo'), 'r') as f:
+            txt = f.read()
+
+        for c in ["Wrong1", "Wrong2"]:
+            with self.assertRaises(tree.ModificationTargetNotFound):
+                ast_tree = parser.parse(txt)
+                flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name=c))
+
+        for c in ["Good1", "Good2"]:
+            ast_tree = parser.parse(txt)
+            flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name=c))
+
     def test_tree_lookup(self):
         with open(os.path.join(MODEL_DIR, 'TreeLookup.mo'), 'r') as f:
             txt = f.read()


### PR DESCRIPTION
It could happen that a user would apply a symbol modification to e.g.
"my_var", whereas that should have been "My_var". This would silently
fail without applying any modifications at all, which can be very
confusing. Now we check that the targets of the to-be-applied
modifications actually exist.