### PR TITLE
fix bug where flattening takes exponential time

### DIFF
--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -298,7 +298,7 @@ class Symbol(Node):
 
     def __init__(self, **kwargs):
         self.name = ''  # type: str
-        self.type = ComponentRef()  # type: ComponentRef
+        self.type = ComponentRef()  # type: Union[ComponentRef, InstanceClass]
         self.prefixes = []  # type: List[str]
         self.redeclare = False  # type: bool
         self.final = False  # type: bool
@@ -608,6 +608,18 @@ class InstanceClass(Class):
         super().__init__(*args, **kwargs)
         self.modification_environment = ClassModification()
 
+    def copy_including_children(self):
+        symbol_parents = {k: v.type.parent for k,v in self.symbols.items() if isinstance(v.type, InstanceClass)}
+        for k in symbol_parents.keys():
+            self.symbols[k].type.parent = None
+
+        new = super().copy_including_children()
+
+        for k, v in symbol_parents.items():
+            new.symbols[k].type.parent = v
+            self.symbols[k].type.parent = v
+
+        return new
 
 class Tree(Class):
     """

--- a/test/models/DeepCopyTimeout.mo
+++ b/test/models/DeepCopyTimeout.mo
@@ -1,0 +1,39 @@
+model A
+  Real x;
+end A;
+
+model B
+  A y;
+end B;
+
+model Test
+  model C
+    extends B;
+  end C;
+  // time needed for flattening of these symbols increased exponentially
+  C c_1;
+  C c_2;
+  C c_3;
+  C c_4;
+  C c_5;
+  C c_6;
+  C c_7;
+  C c_8;
+  C c_9;
+  C c_10;
+  C c_11;
+  C c_12;
+  C c_13;
+  C c_14;
+  C c_15;
+  C c_16;
+  C c_17;
+  C c_18;
+  C c_19;
+  C c_20;
+  C c_21;
+  C c_22;
+  C c_23;
+  C c_24;
+  C c_25;
+end Test;


### PR DESCRIPTION
In some specific cases, a reference to the root
ast tree would remain when making a deep_copy.
Each symbol instantiation then takes exponentially
more time.