### PR TITLE
Move delay duration check to post simplification

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -107,6 +107,8 @@ def _compile_model(model_folder: str, model_name: str, compiler_options: Dict[st
     if compiler_options.get('verbose', False):
         model.check_balanced()
 
+    model._post_checks()
+
     return model
 
 def _codegen_model(model_folder: str, f: ca.Function, library_name: str):

--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -184,20 +184,6 @@ class Generator(TreeListener):
         if len(tree.statements) + len(tree.initial_statements) > 0:
             raise NotImplementedError('Statements are currently supported inside functions only')
 
-        # We do not support delayMax yet, so delay durations can only depend
-        # on constants, parameters and fixed inputs.
-        if self.model.delay_states:
-            delay_durations = ca.veccat(*(x.duration for x in self.model.delay_arguments))
-            disallowed_duration_symbols = ca.vertcat(self.model.time,
-                ca.veccat(*self.model._symbols(self.model.states)),
-                ca.veccat(*self.model._symbols(self.model.der_states)),
-                ca.veccat(*self.model._symbols(self.model.alg_states)),
-                ca.veccat(*(x.symbol for x in self.model.inputs if not x.fixed)))
-
-            if ca.depends_on(delay_durations, disallowed_duration_symbols):
-                raise ValueError(
-                    "Delay durations can only depend on parameters, constants and fixed inputs.")
-
         self.entered_classes.pop()
 
     def exitArray(self, tree):


### PR DESCRIPTION
Only with alias detection we would typically know if a delay duration is
an alg_state (or function thereof), or a fixed input. We therefore
should do the check _after_ simplifications, in the newly made
_post_checks() method.