### PR TITLE
Add extension to model cache file

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -175,7 +175,7 @@ def save_model(model_folder: str, model_name: str, model: Model,
             objects[o] = f
 
     # Output metadata
-    db_file = os.path.join(model_folder, model_name)
+    db_file = os.path.join(model_folder, model_name + ".pymoca_cache")
     with open(db_file, 'wb') as f:
         db = {}
 
@@ -249,7 +249,7 @@ def load_model(model_folder: str, model_name: str, compiler_options: Dict[str, s
     :returns: CachedModel instance.
     """
 
-    db_file = os.path.join(model_folder, model_name)
+    db_file = os.path.join(model_folder, model_name + ".pymoca_cache")
 
     if compiler_options.get('mtime_check', True):
         # Mtime check

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -756,7 +756,7 @@ class GenCasadiTest(unittest.TestCase):
 
     def test_variable_metadata_function(self):
         # Clear cache
-        db_file = os.path.join(MODEL_DIR, 'ParameterAttributes')
+        db_file = os.path.join(MODEL_DIR, 'ParameterAttributes.pymoca_cache')
         try:
             os.remove(db_file)
         except FileNotFoundError:
@@ -817,7 +817,7 @@ class GenCasadiTest(unittest.TestCase):
 
     def test_cache(self):
         # Clear cache
-        db_file = os.path.join(MODEL_DIR, 'Aircraft')
+        db_file = os.path.join(MODEL_DIR, 'Aircraft.pymoca_cache')
         try:
             os.remove(db_file)
         except FileNotFoundError:
@@ -840,7 +840,7 @@ class GenCasadiTest(unittest.TestCase):
 
     def test_cache_delay_arguments(self):
         # Clear cache
-        db_file = os.path.join(MODEL_DIR, 'Delay')
+        db_file = os.path.join(MODEL_DIR, 'Delay.pymoca_cache')
         try:
             os.remove(db_file)
         except FileNotFoundError:
@@ -860,7 +860,7 @@ class GenCasadiTest(unittest.TestCase):
 
     def test_codegen(self):
         # Clear cache
-        db_file = os.path.join(MODEL_DIR, 'Aircraft')
+        db_file = os.path.join(MODEL_DIR, 'Aircraft.pymoca_cache')
         try:
             os.remove(db_file)
         except FileNotFoundError:


### PR DESCRIPTION
This uniquely identifies the model cache files, making them easy to e.g.
ignore in .gitignore files.

Closes #154