### PR TITLE
Coerce lists stored as arrays to MX

### DIFF
--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -336,11 +336,15 @@ class Generator(TreeListener):
             src_left = ca.vertcat(*[self.get_mx(c) for c in tree.left])
         else:
             src_left = self.get_mx(tree.left)
+            if isinstance(src_left, list):
+                src_left = ca.vertcat(*src_left)
 
         if isinstance(tree.right, list):
             src_right = ca.vertcat(*[self.get_mx(c) for c in tree.right])
         else:
             src_right = self.get_mx(tree.right)
+            if isinstance(src_right, list):
+                src_right = ca.vertcat(*src_right)
 
         src_left = ca.MX(src_left)
         src_right = ca.MX(src_right)


### PR DESCRIPTION
Arrays are stored as lists in self.src, but need to be converted to
ca.MX types when we construct equations. Here we detect and do the
coersion using ca.vertcat()

Closes #160