### PR TITLE
Fix initialization of derivative symbol in some cases

### DIFF
--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -689,7 +689,10 @@ class Generator(TreeListener):
             dep = s.dep()
             if dep.name() not in self.derivative:
                 der_dep = _new_mx("der({})".format(dep.name()), dep.size())
+                der_dep._modelica_shape = \
+                    self.nodes[self.current_class][dep.name()]._modelica_shape
                 self.derivative[dep.name()] = der_dep
+                self.nodes[self.current_class][der_dep.name()] = der_dep
                 return der_dep[slice_info['start']:slice_info['stop']:slice_info['step']]
             else:
                 return self.derivative[dep.name()][slice_info['start']:slice_info['stop']:slice_info['step']]

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -2092,6 +2092,44 @@ class GenCasadiTest(unittest.TestCase):
         self.assertEqual(casadi_model.parameters[0].value.name(), c1.name())
         self.assertEqual(casadi_model.parameters[1].value.name(), c2.name())
 
+    def test_derivative_(self):
+        # The initial equation is encountered first, and should properly
+        # initialize the corresponding symbol for the derivative.
+        txt = """
+            model A
+              Real x[3], y;
+            equation
+              for i in 2:3 loop
+                der(x[i]) = x[i] + y;
+              end for;
+            end A;
+
+            model Test
+              A a;
+
+            initial equation
+              der(a.x[2]) = 0.0;
+            end Test;
+            """
+
+        ast_tree = parser.parse(txt)
+        casadi_model = gen_casadi.generate(ast_tree, 'Test')
+
+        ref_model = Model()
+
+        a_x = ca.MX.sym('a.x', 3)
+        a_y = ca.MX.sym('a.y')
+        der_a_x = ca.MX.sym('der(a.x)', 3)
+
+        ref_model.alg_states = [Variable(a_y)]
+        ref_model.states = [Variable(a_x)]
+        ref_model.der_states = [Variable(der_a_x)]
+
+        ref_model.initial_equations = [der_a_x[1]]
+        ref_model.equations = [der_a_x[1:3] - (a_x[1:3] - a_y)]
+
+        self.assert_model_equivalent(ref_model, casadi_model)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If the first encountered expression of a certain derivative was something
like "der(x[1])", the symbol for the derivative was not properly
inititialized.

Note that if the first encountered expression was instead something like
"der(x)" or "der(x[i])" (like in for loops), the initialization was done
correctly. Encountering an expression like "der(x[1])" afterwards would
then also not lead to any problems.

Closes #163