### PR TITLE
Fix infinite recursion if class inherits itself

### DIFF
--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -225,6 +225,9 @@ def flatten_extends(orig_class: Union[ast.Class, ast.InstanceClass], modificatio
     for extends in orig_class.extends:
         c = orig_class.find_class(extends.component, check_builtin_classes=True)
 
+        if str(c.full_reference()) == str(orig_class.full_reference()):
+            raise Exception("Cannot extend class '{}' with itself".format(c.full_reference()))
+
         if c.type == "__builtin":
             if len(orig_class.extends) > 1:
                 raise Exception(

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -333,6 +333,20 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(flat_tree.classes['A'].symbols['dummy_parameter'].unit.value, "m/s")
         self.assertEqual(flat_tree.classes['A'].symbols['dummy_parameter'].value.value, 10.0)
 
+    def test_extend_from_self(self):
+        txt = """
+        model A
+          extends A;
+        end A;"""
+
+        ast_tree = parser.parse(txt)
+
+        class_name = 'A'
+        comp_ref = ast.ComponentRef.from_string(class_name)
+
+        with self.assertRaisesRegex(Exception, "Cannot extend class 'A' with itself"):
+            flat_tree = tree.flatten(ast_tree, comp_ref)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Inheriting from oneself does not make any sense, so we detect it and raise
an Exception.

Closes #152