### PR TITLE
Warn instead of raise exception when exceeding substitute loop limit

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -348,7 +348,7 @@ class Model:
                     if converged:
                         break
                 else:
-                    raise Exception("Substitution of expressions exceeded maximum iteration limit.")
+                    logger.warning("Substitution of expressions exceeded maximum iteration limit.")
 
                 if len(self.equations) > 0:
                     self.equations = ca.substitute(self.equations, symbols, values)
@@ -389,7 +389,7 @@ class Model:
                     if converged:
                         break
                 else:
-                    raise Exception("Substitution of expressions exceeded maximum iteration limit.")
+                    logger.warning("Substitution of expressions exceeded maximum iteration limit.")
 
                 if len(self.equations) > 0:
                     self.equations = ca.substitute(self.equations, symbols, values)
@@ -647,7 +647,7 @@ class Model:
                     if converged:
                         break
                 else:
-                    raise Exception("Substitution of expressions exceeded maximum iteration limit.")
+                    logger.warning("Substitution of expressions exceeded maximum iteration limit.")
 
                 if len(self.equations) > 0:
                     self.equations = ca.substitute(self.equations, variables, values)


### PR DESCRIPTION
CasADi is_equal() has trouble with if statements causing the loop
to exceed the limit even though the expressions have converged.

Therefore, until this issue has been addressed by the CasADi developers,
we raise a warning rather than an exception when this happens.