### PR TITLE
CasADi model, symbol values:  Interpret lists of lists of numbers as DM

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -961,7 +961,13 @@ class Model:
             attribute_lists = [[] for i in range(len(CASADI_ATTRIBUTES))]
             for variable in variable_list:
                 for attribute_list_index, attribute in enumerate(CASADI_ATTRIBUTES):
-                    value = ca.MX(getattr(variable, attribute))
+                    value = getattr(variable, attribute)
+                    # Try casting to DM first, in case we have a nested list that needs to be interpreted as a matrix.
+                    try:
+                        value = ca.DM(value)
+                    except:
+                        pass
+                    value = ca.MX(value)
                     if value.is_zero():
                         value = zero
                     elif value.is_one():

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -583,11 +583,12 @@ class GenCasadiTest(unittest.TestCase):
         E = ca.MX.sym("E", 2, 3)
         I = ca.MX.sym("I", 5, 5)
         F = ca.MX.sym("F", 3, 3)
+        G = ca.MX.sym("G", 3, 3)
 
         ref_model.alg_states = list(map(Variable, [A, b, c, d]))
-        ref_model.constants = list(map(Variable, [C, D, E, I, F]))
+        ref_model.constants = list(map(Variable, [C, D, E, I, F, G]))
         constant_values = [1.7 * ca.DM.ones(2, 3), ca.DM.zeros(3, 2), ca.DM.ones(2, 3), ca.DM.eye(5),
-                                     ca.DM.triplet([0, 1, 2], [0, 1, 2], [1, 2, 3], 3, 3)]
+                                     ca.DM.triplet([0, 1, 2], [0, 1, 2], [1, 2, 3], 3, 3), ca.DM.zeros(3, 3)]
         for const, val in zip(ref_model.constants, constant_values):
             const.value = val
         ref_model.equations = [ca.mtimes(A, b) - c, ca.mtimes(A.T, b) - d, F[1, 2]]

--- a/test/models/MatrixExpressions.mo
+++ b/test/models/MatrixExpressions.mo
@@ -9,6 +9,7 @@ model MatrixExpressions
     constant Real E[2, 3] = ones(2, 3);
     constant Real I[5, 5] = identity(5);
     constant Real F[3, 3] = diagonal({1, 2, 3});
+    constant Real G[3, 3] = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
 equation
     A*b = c;
     transpose(A)*b = d;


### PR DESCRIPTION
This fixes an issue where direct matrix assignments were broken.