### PR TITLE
Proposal to add two custom builtin functions to do 1D and 2D interpolation

### DIFF
--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -6,7 +6,7 @@ from collections import namedtuple, deque, OrderedDict
 import casadi as ca
 import numpy as np
 import itertools
-from typing import Union, Dict
+from typing import Union, Dict, Iterable
 
 from pymoca import ast
 from pymoca.tree import TreeWalker, TreeListener, flatten

--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -295,7 +295,7 @@ class Generator(TreeListener):
 
             delay_argument = DelayArgument(expr, duration)
             self.model.delay_arguments.append(delay_argument)
-        elif op == '_pymoca_interp1d' and n_operands == 3:
+        elif op == '_pymoca_interp1d' and n_operands >= 3 and n_operands <= 4:
             entered_class = self.entered_classes[-1]
             if isinstance(tree.operands[0], ast.ComponentRef):
                 xp = self.get_mx(entered_class.symbols[tree.operands[0].name].value)
@@ -306,9 +306,14 @@ class Generator(TreeListener):
             else:
                 yp = self.get_mx(tree.operands[1])
             arg = self.get_mx(tree.operands[2])
-            func = ca.interpolant('interpolant', 'linear', [xp], yp)
+            if n_operands == 4:
+                assert isinstance(tree.operands[3], ast.Primary)
+                mode = tree.operands[3].value
+            else:
+                mode = 'linear'
+            func = ca.interpolant('interpolant', mode, [xp], yp)
             src = func(arg)
-        elif op == '_pymoca_interp2d' and n_operands == 5:
+        elif op == '_pymoca_interp2d' and n_operands >= 5 and n_operands <= 6:
             entered_class = self.entered_classes[-1]
             if isinstance(tree.operands[0], ast.ComponentRef):
                 xp = self.get_mx(entered_class.symbols[tree.operands[0].name].value)
@@ -324,7 +329,12 @@ class Generator(TreeListener):
                 zp = self.get_mx(tree.operands[2])
             arg_1 = self.get_mx(tree.operands[3])
             arg_2 = self.get_mx(tree.operands[4])
-            func = ca.interpolant('interpolant', 'linear', [xp, yp], np.array(zp).ravel(order='F'))
+            if n_operands == 6:
+                assert isinstance(tree.operands[5], ast.Primary)
+                mode = tree.operands[5].value
+            else:
+                mode = 'linear'
+            func = ca.interpolant('interpolant', mode, [xp, yp], np.array(zp).ravel(order='F'))
             src = func(ca.vertcat(arg_1, arg_2))
         elif op in OP_MAP and n_operands == 2:
             lhs = ca.MX(self.get_mx(tree.operands[0]))

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -9,7 +9,7 @@ import copy  # TODO
 import logging
 import sys
 from collections import OrderedDict
-from typing import Union
+from typing import Union, Iterable
 import os
 
 import numpy as np
@@ -170,6 +170,9 @@ class TreeWalker:
             return True
         return False
 
+    def order_keys(self, keys: Iterable[str]):
+        return keys
+
     def walk(self, listener: TreeListener, tree: ast.Node) -> None:
         """
         Walks an AST tree recursively
@@ -182,7 +185,7 @@ class TreeWalker:
             getattr(listener, 'enterEvery')(tree)
         if hasattr(listener, 'enter' + name):
             getattr(listener, 'enter' + name)(tree)
-        for child_name in tree.__dict__.keys():
+        for child_name in self.order_keys(tree.__dict__.keys()):
             if self.skip_child(tree, child_name):
                 continue
             self.handle_walk(listener, tree.__dict__[child_name])

--- a/test/models/Interpolate.mo
+++ b/test/models/Interpolate.mo
@@ -1,0 +1,9 @@
+model Interpolate
+    parameter Real xp[3] = {0.0, 1.0, 2.0};
+    parameter Real yp[3] = {0.0, 1.0, 4.0};
+    parameter Real zp[3, 3] = {{0.0, 0.0, 0.0}, {0.0, 1.0, 4.0}, {0.0, 2.0, 8.0}};
+    Real x, y, z;
+equation
+    y = _pymoca_interp1d(xp, yp, x);
+    z = _pymoca_interp2d(xp, yp, zp, x, y);
+end Interpolate;

--- a/test/models/Interpolate.mo
+++ b/test/models/Interpolate.mo
@@ -5,5 +5,5 @@ model Interpolate
     Real x, y, z;
 equation
     y = _pymoca_interp1d(xp, yp, x);
-    z = _pymoca_interp2d(xp, yp, zp, x, y);
+    z = _pymoca_interp2d(xp, yp, zp, x, y, "linear");
 end Interpolate;


### PR DESCRIPTION
Interpolation is not officially supported by the Modelica core, whence the proposed builtins are prefix with the string "_pymoca_": _pymoca_interp1d and _pymoca_interp2d.