### PR TITLE
Tree: Fix handling of constant input value attribute

### DIFF
--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -991,7 +991,8 @@ def add_state_value_equations(node: ast.Node) -> None:
     non_state_prefixes = {'constant', 'parameter'}
     for sym in node.symbols.values():
         if not (isinstance(sym.value, ast.Primary) and sym.value.value is None):
-            if len(non_state_prefixes & set(sym.prefixes)) == 0:
+            is_const_input = 'input' in sym.prefixes and isinstance(sym.fixed, ast.Primary) and sym.fixed.value is True
+            if len(non_state_prefixes & set(sym.prefixes)) == 0 and not is_const_input:
                 node.equations.append(ast.Equation(left=sym, right=sym.value))
                 sym.value = ast.Primary(value=None)
 


### PR DESCRIPTION
Just like parameters and constants, the value attribute on a constant
input should not be replaced by an equation; it should be left as-is.

- [ ] Breaks/incompatible with the 'InlineAssignment' model
- [ ] Add test to catch this bug
- [ ] Also merge to stable branch

Thinking about it, I would think the 'InlineAssignment' model would be better formulated like 
```Modelica
model InlineAssignment
    Real x = y;
    input Real y(fixed=true);
end InlineAssignment;
```
Setting a constant input equal to a state does not make sense to me, but the reverse does. Not quite sure if we can catch the difference though.