### PR TITLE
Split installation dependencies per backend

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include requirements.txt
 include LICENSE
 include README.md
 recursive-include doc *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-antlr4-python3-runtime  > 4.5
-matplotlib >= 1.3.1
-sympy >= 0.7.6.1
-scipy >= 0.13.3
-numpy >= 1.8.2
-jinja2 >= 2.7.2
-casadi >= 3.4.0
-lxml >= 3.5.0

--- a/setup.py
+++ b/setup.py
@@ -90,8 +90,27 @@ def setup_package():
     """
     Setup the package.
     """
-    with open('requirements.txt', 'r') as req_file:
-        install_reqs = req_file.read().split('\n')
+
+    extras_require = {
+        # Backends
+        'casadi': ['casadi >= 3.4.0'],
+        'lxml': [
+            'lxml >= 3.5.0',
+            'scipy >= 0.13.3',
+        ],
+        'sympy': [
+            'sympy >= 0.7.6.1',
+            'scipy >= 0.13.3',
+        ],
+        # Examples
+        'examples': [
+            'jupyterlab',
+            'matplotlib'
+        ],
+        'all': []  # Automatically generated below
+
+    }
+    extras_require['all'] = sorted({r for l in extras_require.values() for r in l})
 
     cmdclass_ = {'antlr': AntlrBuildCommand}
     cmdclass_.update(versioneer.get_cmdclass())
@@ -110,8 +129,12 @@ def setup_package():
         license='BSD',
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms=["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
-        install_requires=install_reqs,
+        install_requires=[
+            "antlr4-python3-runtime > 4.5",
+            "numpy >= 1.8.2",
+        ],
         tests_require=['coverage >= 3.7.1', 'nose >= 1.3.1'],
+        extras_require=extras_require,
         test_suite='nose.collector',
         python_requires='>=3.5',
         packages=find_packages("src"),

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,12 @@ envlist =
 
 
 [testenv]
-deps = -rrequirements.txt
+extras = all
 commands = python setup.py test {posargs}
 
 
 [testenv:py37]
-deps =
-    -rrequirements.txt
-    coverage
+deps = coverage
 commands = coverage run --parallel setup.py test {posargs}
 
 


### PR DESCRIPTION
- [x] Make sure to tag 0.5.x, as this is backwards incompatible. Others will need to expliticly specify the backends they use when relying on us now, e.g . "pymoca[casadi]"  instead of just "pymoca".