### PR TITLE
CasADi: Fix detection of cache for invalid CasADi version

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -271,7 +271,13 @@ def load_model(model_folder: str, model_name: str, compiler_options: Dict[str, s
 
     # Load metadata
     with open(db_file, 'rb') as f:
-        db = pickle.load(f)
+        try:
+            db = pickle.load(f)
+        except RuntimeError as e:
+            if "DeserializingStream" in str(e):
+                raise InvalidCacheError('Cache generated for incompatible CasADi version')
+            else:
+                raise
 
         if db['version'] != __version__:
             raise InvalidCacheError('Cache generated for a different version of pymoca')


### PR DESCRIPTION
When we unpickle a CasADi object, it performs a check that it can
actually deserialize it. If it does not succeed, it raises a
RuntimeException saying so. We do not need to bother users with this
exception, and instead just recompile the modile.