### PR TITLE
CasADi/simplify: Fix assertion on expand_mx

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -511,8 +511,8 @@ class Model:
             # circuited MX if-else expressions, we can end up in an infinite
             # loop. With expanded (to SX and back) equations we are safe, as
             # SX does not support short-circuiting.
-            assert options.get('expand_mx', True), \
-                "The current implementation assumes that the option 'expand_mx' is set to True"
+            if not options.get('expand_mx', False):
+                raise Exception("The use of `eliminable_variable_expression` requires `expand_mx` set to True")
 
             p = re.compile(options['eliminable_variable_expression'])
 

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -1150,7 +1150,8 @@ class GenCasadiTest(unittest.TestCase):
     def test_simplify_eliminable_variable_expression(self):
         # Create model, cache it, and load the cache
         compiler_options = \
-            {'eliminable_variable_expression': r'_\w+'}
+            {'eliminable_variable_expression': r'_\w+',
+             'expand_mx': True}
 
         casadi_model = transfer_model(MODEL_DIR, 'Simplify', compiler_options)
 
@@ -1437,7 +1438,8 @@ class GenCasadiTest(unittest.TestCase):
              'eliminate_constant_assignments': True,
              'detect_aliases': True,
              'eliminable_variable_expression': r'_\w+',
-             'reduce_affine_expression': True}
+             'reduce_affine_expression': True,
+             'expand_mx': True}
 
         casadi_model = transfer_model(MODEL_DIR, 'Simplify', compiler_options)
 
@@ -1529,7 +1531,8 @@ class GenCasadiTest(unittest.TestCase):
     def test_simplify_differentiated_state(self):
         # Create model, cache it, and load the cache
         compiler_options = \
-            {'eliminable_variable_expression': r'_\w+'}
+            {'eliminable_variable_expression': r'_\w+',
+             'expand_mx': True}
 
         casadi_model = transfer_model(MODEL_DIR, 'SimplifyDifferentiatedState', compiler_options)
 


### PR DESCRIPTION
The default value of `expand_mx` is False, not True. We should also
raise an Exception, as the error is user facing and can commonly occur.