### PR TITLE
CasADi: Fix small nominals on aliases by making default nominal zero

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -30,7 +30,7 @@ class Variable:
         self.start = 0
         self.min = -np.inf
         self.max = np.inf
-        self.nominal = 1
+        self.nominal = 0
         self.fixed = False
 
     def __str__(self):

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -1287,6 +1287,24 @@ class GenCasadiTest(unittest.TestCase):
         self.assert_model_equivalent_numeric(casadi_model, ref_model)
         self.assertEqual(casadi_model.states[0].aliases, {'alias'})
 
+    def test_simplify_alias_small_nominal(self):
+        # Create model, cache it, and load the cache
+        compiler_options = \
+            {'detect_aliases': True}
+
+        casadi_model = transfer_model(MODEL_DIR, 'SmallNominal', compiler_options)
+
+        ref_model = Model()
+
+        x = ca.MX.sym('x')
+
+        ref_model.alg_states = list(map(Variable, [x]))
+        ref_model.alg_states[0].nominal = 0.1
+
+        # Compare
+        self.assert_model_equivalent_numeric(casadi_model, ref_model)
+        self.assertEquals(casadi_model.alg_states[0].aliases, {'alias'})
+
     def test_simplify_detect_negative_alias(self):
         # Create model, cache it, and load the cache
         compiler_options = \

--- a/test/models/SmallNominal.mo
+++ b/test/models/SmallNominal.mo
@@ -1,0 +1,6 @@
+model SmallNominal
+    Real x;
+    Real alias(nominal = 0.1);
+equation
+    alias = x;
+end SmallNominal;


### PR DESCRIPTION
Before this commit, the default nominal was 1.0. If a user explicitly
set a nominal of e.g. 0.1 on a variable, but would not set a nominal on
an alias thereof, the alias detection would end up with a nominal of
1.0.

This problem is easily fixed by setting the default nominal to 0.0,
which would mean that it is not set.