### PR TITLE
CasADi: Fix expand vectors for fill()/eye()/...

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -275,11 +275,16 @@ class Model:
                                 if np.isscalar(value):
                                     # Just assign without indexing
                                     val = value
-                                else:
-                                    assert isinstance(value, list)
+                                elif isinstance(value, list):
                                     val = value
                                     for i in ind:
                                         val = val[i]
+                                elif isinstance(value, (ca.DM, np.ndarray)):
+                                    val = value[ind]
+                                    if old_var.python_type in {float, int}:
+                                        val = old_var.python_type(val)
+                                else:
+                                    assert False, "Unexpected type from CasADi generator"
                             else:
                                 if np.prod(value.shape) == 1:
                                     # Just assign without indexing

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -753,6 +753,30 @@ class GenCasadiTest(unittest.TestCase):
             self.assertEqual(param_symbols[flat_index].name(), "x[{}]".format(",".join((str(x + 1) for x in ind))))
             self.assertEqual(casadi_model.parameters[flat_index].value, target_param_values[ind])
 
+    def test_array_expand(self):
+        casadi_model = transfer_model(MODEL_DIR, 'ArrayExpand', {'expand_vectors': True})
+
+        target_values = {}
+        target_values['x'] = np.array([[ -5.326999,  54.050758,  0.000000],
+                                       [ -1.0,        0.0,       0.0]], dtype=float)
+        target_values['y'] = np.full((2, 2), -999, dtype=int)
+        target_values['z'] = np.full((2, 2), -999.0, dtype=float)
+
+        types = {'x': float, 'y': int, 'z': float}
+
+        param_symbols = {}
+
+        for x in casadi_model.parameters:
+            param_symbols.setdefault(x.symbol.name()[0], []).append(x)
+
+        for v, target_param_values in target_values.items():
+            for ind in np.ndindex(target_param_values.shape):
+                flat_index = np.ravel_multi_index(ind, target_param_values.shape)
+                variable = param_symbols[v][flat_index]
+                val = variable.value
+                self.assertEqual(val, target_param_values[ind], variable.symbol.name())
+                self.assertIsInstance(val, types[v], variable.symbol.name())
+
     def test_attributes(self):
         with open(os.path.join(MODEL_DIR, 'Attributes.mo'), 'r') as f:
             txt = f.read()

--- a/test/models/ArrayExpand.mo
+++ b/test/models/ArrayExpand.mo
@@ -1,0 +1,8 @@
+model ArrayExpand
+    parameter Real x[:, :] = {{ -5.326999,  54.050758,  0.000000},
+                              { -1.0,        0.0,       0.0}};
+
+    parameter Integer y[2, 2] = fill(-999, 2, 2);
+
+    parameter Real z[2, 2] = fill(-999.0, 2, 2);
+end ArrayExpand;


### PR DESCRIPTION
A fill/eye call would result in a ca.DM object, and not a list as was
asserted in model.py. The expansion code is fixed to account for ca.DM
and np.ndarray types as well. In line with 7f9fd64 we also force a
conversion to the Variable's Python type (float or int).