### PR TITLE
CasADi: Warn if start attribute of alias conflicts

### DIFF
--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -316,8 +316,7 @@ class Symbol(Node):
         self.outer = False  # type: bool
         self.dimensions = [[Primary(value=None)]]  # type: List[List[Union[Expression, Primary, ComponentRef]]]
         self.comment = ''  # type: str
-        # params start value is 0 by default from Modelica spec
-        self.start = Primary(value=0)  # type: Union[Expression, Primary, ComponentRef, Array]
+        self.start = Primary(value=None)  # type: Union[Expression, Primary, ComponentRef, Array]
         self.min = Primary(value=None)  # type: Union[Expression, Primary, ComponentRef, Array]
         self.max = Primary(value=None)  # type: Union[Expression, Primary, ComponentRef, Array]
         self.nominal = Primary(value=None)  # type: Union[Expression, Primary, ComponentRef, Array]

--- a/src/pymoca/backends/sympy/generator.py
+++ b/src/pymoca/backends/sympy/generator.py
@@ -98,7 +98,7 @@ class {{tree.name}}(OdeModel):
         self.x = sympy.Matrix([{{ states_str }}])
         self.x0 = {
             {% for s in states -%}
-            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value else tree.symbols[s.name].start.value}},
+            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else tree.symbols[s.name].start.value}},
             {% endfor -%}}
 
         # variables
@@ -114,7 +114,7 @@ class {{tree.name}}(OdeModel):
         self.c = sympy.Matrix([{{ constants_str }}])
         self.c0 = {
             {% for s in constants -%}
-            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value else tree.symbols[s.name].start.value}},
+            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else tree.symbols[s.name].start.value}},
             {% endfor -%}}
 
         # parameters
@@ -124,7 +124,7 @@ class {{tree.name}}(OdeModel):
         self.p = sympy.Matrix([{{ parameters_str }}])
         self.p0 = {
             {% for s in parameters -%}
-            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value else tree.symbols[s.name].start.value}},
+            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else tree.symbols[s.name].start.value}},
             {% endfor -%}}
 
         # inputs
@@ -134,7 +134,7 @@ class {{tree.name}}(OdeModel):
         self.u = sympy.Matrix([{{ inputs_str }}])
         self.u0 = {
             {% for s in inputs -%}
-            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value else tree.symbols[s.name].start.value}},
+            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else tree.symbols[s.name].start.value}},
             {% endfor -%}}
 
         # outputs

--- a/src/pymoca/backends/sympy/generator.py
+++ b/src/pymoca/backends/sympy/generator.py
@@ -98,7 +98,7 @@ class {{tree.name}}(OdeModel):
         self.x = sympy.Matrix([{{ states_str }}])
         self.x0 = {
             {% for s in states -%}
-            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else tree.symbols[s.name].start.value}},
+            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else (tree.symbols[s.name].start.value or 0.0)}},
             {% endfor -%}}
 
         # variables
@@ -114,7 +114,7 @@ class {{tree.name}}(OdeModel):
         self.c = sympy.Matrix([{{ constants_str }}])
         self.c0 = {
             {% for s in constants -%}
-            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else tree.symbols[s.name].start.value}},
+            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else (tree.symbols[s.name].start.value or 0.0)}},
             {% endfor -%}}
 
         # parameters
@@ -124,7 +124,7 @@ class {{tree.name}}(OdeModel):
         self.p = sympy.Matrix([{{ parameters_str }}])
         self.p0 = {
             {% for s in parameters -%}
-            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else tree.symbols[s.name].start.value}},
+            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else (tree.symbols[s.name].start.value or 0.0)}},
             {% endfor -%}}
 
         # inputs
@@ -134,7 +134,7 @@ class {{tree.name}}(OdeModel):
         self.u = sympy.Matrix([{{ inputs_str }}])
         self.u0 = {
             {% for s in inputs -%}
-            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else tree.symbols[s.name].start.value}},
+            {{render.src[s]}} : {{tree.symbols[s.name].value.value if tree.symbols[s.name].value.value is not none else (tree.symbols[s.name].start.value or 0.0)}},
             {% endfor -%}}
 
         # outputs

--- a/src/pymoca/backends/xml/generator.py
+++ b/src/pymoca/backends/xml/generator.py
@@ -57,9 +57,6 @@ class XmlGenerator(TreeListener):
             val = getattr(tree, f).value
             if val is None:
                 continue
-            if val == 0 and f == 'start':
-                # this is already default
-                continue
             items.append(
                 E('item', E('real', value=str(val)), name=f))
 

--- a/test/models/ConflictingAliasStart.mo
+++ b/test/models/ConflictingAliasStart.mo
@@ -1,0 +1,10 @@
+model ConflictingAliasStart
+    parameter Real p1;
+    Real x(min = 0, max = 3, nominal = 10, start = p1);
+    Real alias_neg(min = -2, max = -1, nominal = 1, start = p1);
+    Real alias_pos(start = 4);
+equation
+    der(x) = x;
+    alias_neg = -x;
+    alias_pos = x;
+end ConflictingAliasStart;


### PR DESCRIPTION
Instead of just blindly overwriting the start attribute with that of the
lastest alias, we should check if there is a conflict to avoid suprises.

Note that we cannot exhaustively check for conflicts, because if the
user sets the canonical state's start attribute explicitly to zero, it
will still overwrite it with that of the alias.

Also note that the order in which we loop over aliases is random (due to
the usage of a set), so the order in which messages appear and what
conflict they report can be different. This also means that, in the case
the user does not set a non-zero start attribute on the canonical state
(that is the first encountered alias), but does do so on multiple of its
aliases, the eventual start attribute of the canonical state cannot be
known in advance. This situation should be prevented by making sure that
all aliases have matching (or not-set) start attributes. The warnings we
added in this commit will help with that.

Closes #208