### PR TITLE
Add method to API in order to retrieve the default compiler options

### DIFF
--- a/src/pymoca/backends/casadi/_options.py
+++ b/src/pymoca/backends/casadi/_options.py
@@ -1,0 +1,40 @@
+def _get_default_options():
+    """
+    Returns a dictionary with the available compiler options and the default values
+
+    Returns:
+        default_options (Dict)
+
+    """
+    return {
+        'library_folders': [],
+        'verbose': False,
+        'check_balanced': True,
+        'mtime_check': True,
+        'cache': False,
+        'codegen': False,
+        'expand_mx': False,
+        'unroll_loops': True,
+        'inline_functions': True,
+        'expand_vectors': False,
+        'replace_parameter_expressions': False,
+        'replace_constant_expressions': False,
+        'eliminate_constant_assignments': False,
+        'replace_parameter_values': False,
+        'replace_constant_values': False,
+        'eliminable_variable_expression': None,
+        'factor_and_simplify_equations': False,
+        'detect_aliases': False,
+        'reduce_affine_expression': False,
+    }
+
+
+def _merge_default_options(options):
+    if options is None:
+        return _get_default_options()
+    elif isinstance(options, dict):
+        default_options = _get_default_options()
+        default_options.update(options)
+        return default_options
+    else:
+        raise TypeError('options must be of type dict')

--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -15,6 +15,7 @@ from pymoca import __version__
 from . import generator
 from .alias_relation import AliasRelation
 from .model import CASADI_ATTRIBUTES, Model, Variable, DelayArgument
+from ._options import _merge_default_options, _get_default_options as get_default_options
 
 logger = logging.getLogger("pymoca")
 
@@ -97,7 +98,7 @@ def _compile_model(model_folder: str, model_name: str, compiler_options: Dict[st
 
     # Load folders
     tree = None
-    for folder in [model_folder] + compiler_options.get('library_folders', []):
+    for folder in [model_folder] + compiler_options['library_folders']:
         for root, dir, files in os.walk(folder, followlinks=True):
             for item in fnmatch.filter(files, "*.mo"):
                 logger.info("Parsing {}".format(item))
@@ -112,12 +113,12 @@ def _compile_model(model_folder: str, model_name: str, compiler_options: Dict[st
     logger.info("Generating CasADi model")
 
     model = generator.generate(tree, model_name, compiler_options)
-    if compiler_options.get('check_balanced', True):
+    if compiler_options['check_balanced']:
         model.check_balanced()
 
     model.simplify(compiler_options)
 
-    if compiler_options.get('verbose', False):
+    if compiler_options['verbose']:
         model.check_balanced()
 
     model._post_checks()
@@ -182,11 +183,13 @@ def save_model(model_folder: str, model_name: str, model: Model,
     :param compiler_options: Dictionary of compiler options.
     """
 
+    compiler_options = _merge_default_options(compiler_options)
+
     objects = {'dae_residual': None, 'initial_residual': None, 'variable_metadata': None, 'delay_arguments': None}
     for o in objects.keys():
         f = getattr(model, o + '_function')
 
-        if compiler_options.get('codegen', False):
+        if compiler_options['codegen']:
             objects[o] = _codegen_model(model_folder, f, '{}_{}'.format(model_name, o))
         else:
             objects[o] = f
@@ -274,12 +277,14 @@ def load_model(model_folder: str, model_name: str, compiler_options: Dict[str, s
     :returns: CachedModel instance.
     """
 
+    compiler_options = _merge_default_options(compiler_options)
+
     db_file = os.path.join(model_folder, model_name + ".pymoca_cache")
 
-    if compiler_options.get('mtime_check', True):
+    if compiler_options['mtime_check']:
         # Mtime check
         cache_mtime = os.path.getmtime(db_file)
-        for folder in [model_folder] + compiler_options.get('library_folders', []):
+        for folder in [model_folder] + compiler_options['library_folders']:
             for root, dir, files in os.walk(folder, followlinks=True):
                 for item in fnmatch.filter(files, "*.mo"):
                     filename = os.path.join(root, item)
@@ -313,7 +318,7 @@ def load_model(model_folder: str, model_name: str, compiler_options: Dict[str, s
             raise InvalidCacheError('Cache generated for different compiler options')
 
         # Pickles are platform independent, but dynamic libraries are not
-        if compiler_options.get('codegen', False):
+        if compiler_options['codegen']:
             if db['library_os'] != os.name:
                 raise InvalidCacheError('Cache generated for incompatible OS')
 
@@ -440,13 +445,11 @@ def load_model(model_folder: str, model_name: str, compiler_options: Dict[str, s
     return model
 
 def transfer_model(model_folder: str, model_name: str, compiler_options=None):
-    if compiler_options is None:
-        compiler_options = {}
-    else:
-        compiler_options = copy.copy(compiler_options)
 
-    cache = compiler_options.setdefault('cache', False)
-    codegen = compiler_options.setdefault('codegen', False)
+    compiler_options = _merge_default_options(compiler_options)
+
+    cache = compiler_options['cache']
+    codegen = compiler_options['codegen']
 
     # Compilation takes precedence over caching, and disables it
     if cache and codegen:
@@ -458,7 +461,7 @@ def transfer_model(model_folder: str, model_name: str, compiler_options=None):
         # expanding to SX. We only raise a warning when we have to (re)compile
         # the model though.
         raise_expand_warning = False
-        if cache and not compiler_options.get('expand_mx', False):
+        if cache and not compiler_options['expand_mx']:
             compiler_options['expand_mx'] = True
             raise_expand_warning = True
 
@@ -472,3 +475,5 @@ def transfer_model(model_folder: str, model_name: str, compiler_options=None):
             return model
     else:
         return _compile_model(model_folder, model_name, compiler_options)
+
+

--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -15,6 +15,8 @@ from .alias_relation import AliasRelation
 from .model import Model, Variable, DelayArgument
 from .mtensor import _MTensor, _new_mx
 
+from ._options import _merge_default_options
+
 logger = logging.getLogger("pymoca")
 
 # TODO
@@ -100,12 +102,12 @@ class Generator(TreeListener):
         self.for_loops = deque()
         self.functions = {}
         self.entered_classes = deque()
-        self.map_mode = 'inline' if options.get('unroll_loops', True) else 'serial'
-        self.function_mode = (True, False) if options.get('inline_functions', True) else (False, True)
+        self.map_mode = 'inline' if options['unroll_loops'] else 'serial'
+        self.function_mode = (True, False) if options['inline_functions'] else (False, True)
         self.delay_counter = 0
 
         # NOTE: Part of MTensor workaround.
-        self._expand_vectors_enabled = options.get('expand_vectors', False)
+        self._expand_vectors_enabled = options['expand_vectors']
 
     @property
     def current_class(self):
@@ -934,8 +936,9 @@ def generate(ast_tree: ast.Tree, model_name: str, options: Dict[str, bool]=None)
     :param options: dictionary of generator options
     :return: casadi model
     """
-    if options is None:
-        options = {}
+    options = _merge_default_options(options)
+
+
     component_ref = ast.ComponentRef.from_string(model_name)
     ast_walker = GeneratorWalker()
     flat_tree = flatten(ast_tree, component_ref)

--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -7,8 +7,10 @@ import re
 import sys
 
 from pymoca import ast
+
 from .alias_relation import AliasRelation
 from .mtensor import _MTensor
+from ._options import _merge_default_options
 
 logger = logging.getLogger("pymoca")
 
@@ -350,7 +352,9 @@ class Model:
         self._substitute_metadata(symbols, values)
 
     def simplify(self, options):
-        if options.get('expand_vectors', False) and options.get('expand_mx', False):
+        options = _merge_default_options(options)
+
+        if options['expand_vectors'] and options['expand_mx']:
             # If we are _not_ expanding MX to SX, we do the expansion of
             # vectors first, such that we are be able to detect more aliases
             # (e.g individual array elements, or elements in a for loop).
@@ -362,7 +366,7 @@ class Model:
             self.equations = self._expand_simplify_mx(self.equations)
             self.initial_equations = self._expand_simplify_mx(self.initial_equations)
 
-        if options.get('replace_parameter_expressions', False):
+        if options['replace_parameter_expressions']:
             logger.info("Replacing parameter expressions")
 
             simple_parameters, symbols, values = [], [], []
@@ -407,7 +411,7 @@ class Model:
                 # Replace parameter expressions in metadata
                 self._substitute_metadata(symbols, values)
 
-        if options.get('replace_constant_expressions', False):
+        if options['replace_constant_expressions']:
             logger.info("Replacing constant expressions")
 
             simple_constants, symbols, values = [], [], []
@@ -443,7 +447,7 @@ class Model:
                 # Replace constant expressions in metadata
                 self._substitute_metadata(symbols, values)
 
-        if options.get('eliminate_constant_assignments', False):
+        if options['eliminate_constant_assignments']:
             logger.info("Elimating constant variable assignments")
 
             alg_states = OrderedDict([(s.symbol.name(), s) for s in self.alg_states])
@@ -490,7 +494,7 @@ class Model:
             self.alg_states = list(alg_states.values())
             self.equations = reduced_equations
 
-        if options.get('replace_parameter_values', False):
+        if options['replace_parameter_values']:
             logger.info("Replacing parameter values")
 
             # N.B. Any parameter expression elimination must be done first.
@@ -511,7 +515,7 @@ class Model:
             # Replace parameter values in metadata
             self._substitute_metadata(symbols, values)
 
-        if options.get('replace_constant_values', False):
+        if options['replace_constant_values']:
             logger.info("Replacing constant values")
 
             # N.B. Any parameter expression elimination must be done first.
@@ -528,14 +532,14 @@ class Model:
             # Replace constant values in metadata
             self._substitute_metadata(symbols, values)
 
-        if options.get('eliminable_variable_expression', None) is not None:
+        if options['eliminable_variable_expression'] is not None:
             logger.info("Elimating variables that match the regular expression {}".format(options['eliminable_variable_expression']))
 
             # Due to CasADi's ca.is_equal not properly matching short-
             # circuited MX if-else expressions, we can end up in an infinite
             # loop. With expanded (to SX and back) equations we are safe, as
             # SX does not support short-circuiting.
-            if not options.get('expand_mx', False):
+            if not options['expand_mx']:
                 raise Exception("The use of `eliminable_variable_expression` requires `expand_mx` set to True")
 
             p = re.compile(options['eliminable_variable_expression'])
@@ -683,11 +687,11 @@ class Model:
                 if len(self.delay_arguments) > 0:
                     self.delay_arguments = self._substitute_delay_arguments(self.delay_arguments, variables, values)
 
-        if options.get('expand_vectors', False) and not options.get('expand_mx', False):
+        if options['expand_vectors'] and not options['expand_mx']:
             # If we are _not_ expanding MX to SX, we do the expansion of vectors here
             self._expand_vectors()
 
-        if options.get('factor_and_simplify_equations', False):
+        if options['factor_and_simplify_equations']:
             # Operations that preserve the equivalence of an equation
             # TODO: There may be more, but this is the most frequent set
             unary_ops = ca.OP_NEG, ca.OP_FABS, ca.OP_SQRT
@@ -722,7 +726,7 @@ class Model:
             # Store changes
             self.equations = simplified_equations
 
-        if options.get('detect_aliases', False):
+        if options['detect_aliases']:
             logger.info("Detecting aliases")
 
             states = OrderedDict([(s.symbol.name(), s) for s in self.states])
@@ -796,7 +800,7 @@ class Model:
                         deps = ca.symvar(eq)
                         assert len(deps) == 2
                         if _make_alias(deps, eq.is_op(ca.OP_ADD)): continue
-                elif options.get('expand_vectors', False) and not options.get('expand_mx', False):
+                elif options['expand_vectors'] and not options['expand_mx']:
                     # Equation might have many "shadow" dependencies due to
                     # vector/array expansion. By using .expand() and SX
                     # symbols for the evaluation, we can figure out what the
@@ -899,7 +903,7 @@ class Model:
             if len(self.delay_arguments) > 0:
                 self.delay_arguments = self._substitute_delay_arguments(self.delay_arguments, variables, values)
 
-        if options.get('reduce_affine_expression', False):
+        if options['reduce_affine_expression']:
             logger.info("Collapsing model into an affine expression")
 
             for equation_list in ['equations', 'initial_equations']:
@@ -937,7 +941,7 @@ class Model:
                     equations = [ca.reshape(ca.mtimes(A, states_vector), equations.shape) + b]
                     setattr(self, equation_list, equations)
 
-        if options.get('expand_mx', False):
+        if options['expand_mx']:
             logger.info("Expanded MX functions will be returned")
             self._expand_mx_func = lambda x: x.expand()
 
@@ -1059,3 +1063,4 @@ class Model:
                  ca.veccat(*self._symbols(self.constants)),
                  ca.veccat(*self._symbols(self.parameters))],
                 out_arguments))
+


### PR DESCRIPTION
I am not sure if writing some documentation is a plan for the future. Nevertheless, I think that getting a list of the available options could come quite handy, especially for newcomers. I generated this list based on the get methods used to access the options dictionary.

I could also write a description of each option in the docString if this sounds useful. 