### PR TITLE
Allow multiple calls to simplify and support iterative_simplification option

### DIFF
--- a/src/pymoca/backends/casadi/_options.py
+++ b/src/pymoca/backends/casadi/_options.py
@@ -26,6 +26,7 @@ def _get_default_options():
         'factor_and_simplify_equations': False,
         'detect_aliases': False,
         'reduce_affine_expression': False,
+        'iterative_simplification': False
     }
 
 

--- a/src/pymoca/backends/casadi/alias_relation.py
+++ b/src/pymoca/backends/casadi/alias_relation.py
@@ -33,6 +33,9 @@ class AliasRelation:
             self._canonical_variables_map[v] = (canonical_a, sign_a)
             self._canonical_variables_map[self.__toggle_sign(v)] = (canonical_a, -sign_a)
 
+    def remove_canonical_variable(self, a):
+        self._canonical_variables.remove(a)
+
     def __toggle_sign(self, v):
         if self.__is_negative(v):
             return v[1:]

--- a/src/pymoca/backends/casadi/alias_relation.py
+++ b/src/pymoca/backends/casadi/alias_relation.py
@@ -8,6 +8,7 @@ class AliasRelation:
         self._aliases = {}
         self._canonical_variables_map = OrderedDict()
         self._canonical_variables = set()
+        self._substituted_aliases = set()
 
     def add(self, a, b):
         # Construct aliases (a set of equivalent variables)
@@ -61,6 +62,9 @@ class AliasRelation:
             else:
                 return a, 1
 
+    def confirm_substitution(self, a):
+        self._substituted_aliases.add(a)
+
     @property
     def canonical_variables(self):
         return self._canonical_variables
@@ -71,3 +75,7 @@ class AliasRelation:
             aliases = self.aliases(canonical_variable).copy()
             aliases.discard(canonical_variable)
             yield canonical_variable, aliases
+
+    @property
+    def substituted_aliases(self):
+        return self._substituted_aliases

--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -460,6 +460,11 @@ class Model:
             for eq in self.equations:
                 if eq.is_symbolic() and eq.name() in alg_states:
                     constant = alg_states.pop(eq.name())
+
+                    if eq.name() in self.alias_relation.canonical_variables:
+                        self.alias_relation.remove_canonical_variable(eq.name())
+                        logger.debug('{} removed from canonical variables'.format(eq.name()))
+
                     constant.value = 0.0
 
                     self.constants.append(constant)
@@ -480,6 +485,10 @@ class Model:
 
                     if variable is not None:
                         constant = alg_states.pop(variable.name())
+
+                        if variable.name() in self.alias_relation.canonical_variables:
+                            self.alias_relation.remove_canonical_variable(variable.name())
+                            logger.debug('{} removed from canonical variables'.format(variable.name()))
 
                         if eq.is_op(ca.OP_SUB):
                             constant.value = value

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -1648,6 +1648,18 @@ class GenCasadiTest(unittest.TestCase):
         # Compare
         self.assert_model_equivalent_numeric(casadi_model, ref_model)
 
+    def test_iterative_simplification(self):
+        compiler_options = {'eliminate_constant_assignments': True,
+                            'factor_and_simplify_equations': True,
+                            'replace_constant_expressions': True,
+                            'replace_constant_values': True,
+                            'detect_aliases': True,
+                            'iterative_simplification': True}
+
+        casadi_model = transfer_model(MODEL_DIR, 'IterativeSimplification', compiler_options)
+
+        self.assertEqual(1, len(casadi_model.equations))
+
     def test_state_annotator(self):
         with open(os.path.join(MODEL_DIR, 'StateAnnotator.mo'), 'r') as f:
             txt = f.read()

--- a/test/models/IterativeSimplification.mo
+++ b/test/models/IterativeSimplification.mo
@@ -1,0 +1,16 @@
+model IterativeSimplification
+Real x(start = 0);
+Real z;
+Real f;
+Real g;
+Real h;
+
+equation
+
+der(x) = 10 + z;
+f = 0;
+g = 1;
+f = (z-h);
+h = g;
+
+end IterativeSimplification;


### PR DESCRIPTION
As discussed in issue #214, calling simply multiple times might cause errors. This pull request solves 2 errors with detect aliases:

- multiple calls to detect aliases that used to fail because when substituting the variable attributes the second time a keyError is raised
- a call chain like detect_aliases - eliminate_constant_assignments - detect_aliases where eliminate_constant_assignments eliminated a canonical variable

Furthermore an option iterative_simplification is implemented to maximize the simplification of particularly tangled models (for example with many connectors and thus many aliases and trivial equations)