### PR TITLE
CasADi: Fix aliasing of algebraic states to constants

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -767,6 +767,7 @@ class Model:
             alg_states = OrderedDict([(s.symbol.name(), s) for s in self.alg_states])
             inputs = OrderedDict([(s.symbol.name(), s) for s in self.inputs])
             parameters = OrderedDict([(s.symbol.name(), s) for s in self.parameters])
+            constants = OrderedDict([(s.symbol.name(), s) for s in self.constants])
 
             all_states = OrderedDict()
             all_states.update(states)
@@ -774,9 +775,11 @@ class Model:
             all_states.update(alg_states)
             all_states.update(inputs)
             all_states.update(parameters)
+            all_states.update(constants)
 
             # For now, we only eliminate algebraic states.
-            do_not_eliminate = set(list(der_states) + list(states) + list(inputs) + list(parameters))
+            do_not_eliminate = set(list(der_states) + list(states) + list(inputs)
+                                   + list(parameters) + list(constants))
 
             # When doing a `detect_aliases` pass multiple times, we have to avoid
             # handling aliases we already handled before as their states no longer

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -1388,6 +1388,54 @@ class GenCasadiTest(unittest.TestCase):
         self.assert_model_equivalent_numeric(casadi_model, ref_model)
         self.assertEqual(casadi_model.states[0].aliases, {'-alias_neg', 'alias_pos'})
 
+    def test_constant_aliases(self):
+        txt = """
+            model ConstantAlias
+
+              Real x;
+              Real z;
+              constant Real c = 0;
+
+              equation
+
+              der(x) = c;
+              z = c;
+
+            end ConstantAlias;
+        """
+
+        ast_tree = parser.parse(txt)
+        casadi_model = gen_casadi.generate(ast_tree, 'ConstantAlias')
+        casadi_model.simplify({'detect_aliases': True})
+
+        c = casadi_model.constants[0]
+        self.assertSetEqual(c.aliases, {'z'})
+        self.assertEqual(len(casadi_model.alg_states), 0)
+
+    def test_parameter_aliases(self):
+        txt = """
+            model ParameterAlias
+
+              Real x;
+              Real z;
+              parameter Real c = 0;
+
+              equation
+
+              der(x) = c;
+              z = c;
+
+            end ParameterAlias;
+        """
+
+        ast_tree = parser.parse(txt)
+        casadi_model = gen_casadi.generate(ast_tree, 'ParameterAlias')
+        casadi_model.simplify({'detect_aliases': True})
+
+        p = casadi_model.parameters[0]
+        self.assertSetEqual(p.aliases, {'z'})
+        self.assertEqual(len(casadi_model.alg_states), 0)
+
     def test_simplify_expand_vectors(self):
         # Create model, cache it, and load the cache
         compiler_options = \


### PR DESCRIPTION
The aliasing of algebraic states to parameters already worked as
expected, but that for constants did not yet. This commit fixes the
latter such that aliasing behavior to constants is similar to that of
parameters.

Two tests have been added. Note that only ConstantAlias model failed
before this commit, and that the ParameterAlias model is added for
completion and easy comparison (i.e. expected aliasing behavior is very
similar in both tests).

Closes #218