### PR TITLE
CasADi: bugfix on iterative detect alias

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -888,7 +888,8 @@ class Model:
                 fixed = canonical_state.fixed
 
                 for alias in aliases:
-                    if alias in old_alias_relation.aliases(canonical):
+                    if len(old_alias_relation.aliases(alias)) > 1 and \
+                            alias not in old_alias_relation.canonical_variables:
                         # We already handled this alias in a previous pass of `detect_aliases`
                         continue
 


### PR DESCRIPTION
The previous logic would fail in the following situation:
- in iteration 1: A is aliased to B and A is deleted
- in iteration 2: B is aliased to C, the canonical variable of A is then C. 
The check `alias in old_alias_relation.aliases(canonical)` which in these case is `A in old_alias_relation.aliases(C)` returns False and an error is raised when A is not found in all_states

I was not able to create a simple example to showcase this. I have this problem with a rather big model. In any case, this solution works with the previous tests and it is rather similar from a logical point of view. 