### PR TITLE
CasADi: Support string parameters in model

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -36,6 +36,8 @@ class CachedModel(Model):
         self.outputs = []
         self.constants = []
         self.parameters = []
+        self.string_constants = []
+        self.string_parameters = []
         self.time = ca.MX.sym('time')
         self.delay_states = []
         self.delay_arguments = []
@@ -57,6 +59,8 @@ class CachedModel(Model):
         r += "outputs: " + str(self.outputs) + "\n"
         r += "constants: " + str(self.constants) + "\n"
         r += "parameters: " + str(self.parameters) + "\n"
+        r += "string_constants: " + str(self.string_constants) + "\n"
+        r += "string_parameters: " + str(self.string_parameters) + "\n"
         return r
 
     @property
@@ -212,6 +216,8 @@ def save_model(model_folder: str, model_name: str, model: Model,
         # Describe variables per category
         for key in ['states', 'der_states', 'alg_states', 'inputs', 'parameters', 'constants']:
             db[key] = [e.to_dict() for e in getattr(model, key)]
+        db['string_constants'] = model.string_constants
+        db['string_parameters'] = model.string_parameters
 
 
         # Caching using CasADi functions will lead to constants seemingly
@@ -348,6 +354,8 @@ def load_model(model_folder: str, model_name: str, compiler_options: Dict[str, s
         model.outputs = db['outputs']
         model.delay_states = db['delay_states']
         model.alias_relation = db['alias_relation']
+        model.string_constants = db['string_constants']
+        model.string_parameters = db['string_parameters']
 
         # Evaluate variable metadata:
         parameter_vector = ca.veccat(*[v.symbol for v in model.parameters])

--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -71,6 +71,32 @@ class Variable:
         return variable
 
 
+class StringVariable:
+    def __init__(self, name):
+        self.name = name
+        self.value = None
+        self.start = ""
+        self.fixed = False
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return '{}:str'.format(self.name)
+
+    def to_dict(self):
+        return {k: getattr(self, k) for k in ["name", "value", "start", "fixed"]}
+
+    @classmethod
+    def from_dict(cls, d):
+        variable = cls(d['name'])
+        variable.value = d['value']
+        variable.start = d['start']
+        variable.fixed = d['fixed']
+
+        return variable
+
+
 DelayArgument = namedtuple('DelayArgument', ['expr', 'duration'])
 
 
@@ -85,6 +111,8 @@ class Model:
         self.outputs = []
         self.constants = []
         self.parameters = []
+        self.string_constants = []
+        self.string_parameters = []
         self.equations = []
         self.initial_equations = []
         self.time = ca.MX.sym('time')
@@ -104,6 +132,8 @@ class Model:
         r += "outputs: " + str(self.outputs) + "\n"
         r += "constants: " + str(self.constants) + "\n"
         r += "parameters: " + str(self.parameters) + "\n"
+        r += "string_constants: " + str(self.string_constants) + "\n"
+        r += "string_parameters: " + str(self.string_parameters) + "\n"
         r += "equations: " + str(self.equations) + "\n"
         r += "initial equations: " + str(self.initial_equations) + "\n"
         return r

--- a/test/models/ParameterAttributes.mo
+++ b/test/models/ParameterAttributes.mo
@@ -1,4 +1,6 @@
 model ParameterAttributes
+	parameter String string_parameter = "test_p";
+	constant String string_constant = "test_c";
 	parameter Real min_ = 3.0;
     parameter Real max_;
 	Real a(min=min_, max=10.0);

--- a/test/models/Simplify.mo
+++ b/test/models/Simplify.mo
@@ -1,4 +1,6 @@
 model Simplify
+    parameter String string_parameter = "test_p";
+    constant String string_constant = "test_c";
     constant Real c = 3.0;
     parameter Real p1 = 2.0;
     parameter Real p2 = 2 * p1;


### PR DESCRIPTION
- [x] Do we want the dae_/initial_dae_/variable_metadata CasADi functions to be a function of string parameters as well? Currently that is the case, but it can look somewhat weird.

Some options are:
1. Keep as is; `model.parameters` contains all parameters regardless of type.  CasADi functions are a function of all parameters.
2. `model.parameters` contains all parameters regardless of type.  CasADi functions are a function of only the numeric parameters.
3. Add `model.string_parameters`, as a separate parameter group for non-numeric parameters. Not an input to any of the CasADi functions.

EDIT:
Options 3 is probably the cleanest one, so going with that one.