### PR TITLE
CasADi/Simplify: Add option to (dis)allow aliasing derivative states

### DIFF
--- a/src/pymoca/backends/casadi/_options.py
+++ b/src/pymoca/backends/casadi/_options.py
@@ -25,6 +25,7 @@ def _get_default_options():
         'eliminable_variable_expression': None,
         'factor_and_simplify_equations': False,
         'detect_aliases': False,
+        'allow_derivative_aliases': True,
         'reduce_affine_expression': False,
     }
 

--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -844,6 +844,12 @@ class Model:
                         # swap the states
                         other_state, alg_state = alg_state, other_state
 
+                # If either state is a derivative state, and aliasing of those
+                # is not allowed, skip aliasing them
+                if (not options['allow_derivative_aliases']
+                        and (alg_state.name() in der_states or other_state.name() in der_states)):
+                    return False
+
                 if alg_state is not None:
                     # Check to see if we are linking two entries in do_not_eliminate
                     if self.alias_relation.canonical_signed(alg_state.name())[0] in do_not_eliminate and \


### PR DESCRIPTION
Some software handles derivate states rather differently from regular
states. For example, the derivative states might not actually be
individual symbols collocated in time, but instead just the difference
between two collocated instances of the associated state (divided by a
time interval).

When an algebraic state is an alias of a derivative state, with the
canonical state he derivative, processing of the aliased (algebraic)
state can then easily fail when it relies on there being associated
collocated symbols. This commit adds an options to disallow aliasing to
derivative states for such software.