### PR TITLE
CasADi/API: Fix always reading .mo files as UTF-8

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -107,7 +107,7 @@ def _compile_model(model_folder: str, model_name: str, compiler_options: Dict[st
             for item in fnmatch.filter(files, "*.mo"):
                 logger.info("Parsing {}".format(item))
 
-                with open(os.path.join(root, item), 'r') as f:
+                with open(os.path.join(root, item), 'r', encoding="utf-8") as f:
                     if tree is None:
                         tree = parser.parse(f.read())
                     else:


### PR DESCRIPTION
According to the specification, Modelica files should always be stored
in UTF-8. If we do not set the encoding when reading Modelica files, we
could get errors on files with special (non-ASCII) characters on
e.g. Shift-JIS platforms.