### PR TITLE
CasADi/API: Fix always reading .mo files as UTF-8

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -103,7 +103,7 @@ def _compile_model(model_folder: str, model_name: str, compiler_options: Dict[st
             for item in fnmatch.filter(files, "*.mo"):
                 logger.info("Parsing {}".format(item))
 
-                with open(os.path.join(root, item), 'r') as f:
+                with open(os.path.join(root, item), 'r', encoding="utf-8") as f:
                     if tree is None:
                         tree = parser.parse(f.read())
                     else:

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,8 @@ commands =
 skip_install = true
 application-import-names = pymoca,test
 deps =
-  flake8
-  flake8-bugbear
-  flake8-comprehensions
-  flake8-import-order
+  flake8==3.7.9
+  flake8-bugbear==20.1.4
+  flake8-comprehensions==3.2.2
+  flake8-import-order==0.18.1
 commands = flake8


### PR DESCRIPTION
According to the specification, Modelica files should always be stored
in UTF-8. If we do not set the encoding when reading Modelica files, we
could get errors on files with special (non-ASCII) characters on
e.g. Shift-JIS platforms.