### PR TITLE
AliasRelation: Fix handling of circular alias dependencies

### DIFF
--- a/src/pymoca/backends/casadi/alias_relation.py
+++ b/src/pymoca/backends/casadi/alias_relation.py
@@ -12,6 +12,11 @@ class AliasRelation:
     def add(self, a, b):
         # Construct aliases (a set of equivalent variables)
         aliases = self.aliases(a)
+        if b in aliases:
+            # Already aliases, nothing more to do
+            assert a in self.aliases(b)
+            return
+
         inverted_aliases = self.aliases(self.__toggle_sign(a))
 
         aliases |= self.aliases(b)

--- a/test/alias_relation_test.py
+++ b/test/alias_relation_test.py
@@ -1,0 +1,16 @@
+import unittest
+
+from pymoca.backends.casadi.alias_relation import AliasRelation
+
+
+class TestAliasRelation(unittest.TestCase):
+
+    def test_double_alias(self):
+        alias_relation = AliasRelation()
+
+        alias_relation.add("a", "b")
+        alias_relation.add("b", "c")
+        alias_relation.add("c", "a")
+
+        self.assertSetEqual(alias_relation.canonical_variables, {"a", })
+        self.assertSetEqual(alias_relation.aliases("a"), {"a", "b", "c"})


### PR DESCRIPTION
The test case that this commit adds describes the problem in a minimal
way. The issue was caught specifically with a single circular pipe
network (all discharges equal), which before this commit resulted in:

- No canonical state of any discharge
- All discharges were part of the algebraic states
- All alias equations for discharges were removed from the model

Basically this meant that every discharge became a free symbol, which is
obviously very wrong. Such networks and sets of equations are not
uncommon, and are definitely not limited to discharges (but all types of
flow quantities).

The fix is rather simple; if the alias relationship we add already
exists, we skip it.