### PR TITLE
CasADi/API: Fix invalid cache check due to CasADi version mismatch

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -305,7 +305,7 @@ def load_model(model_folder: str, model_name: str, compiler_options: Dict[str, s
         try:
             db = pickle.load(f)
         except RuntimeError as e:
-            if "DeserializingStream" in str(e):
+            if "DeserializingStream" in str(e) or "deserialization" in str(e).lower():
                 raise InvalidCacheError('Cache generated for incompatible CasADi version')
             else:
                 raise


### PR DESCRIPTION
A recent CasADi version changed the error message when a pickled MX
function cannot be unpickled due to a version mismatch. This commit
updates the check so that instead of (re)raising the respective
RuntimeError from CasADi, we just recompile the model.