### PR TITLE
Fixes related to NumPy 1.20 (deprecations, behavior changes)

### DIFF
--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -54,7 +54,7 @@ class ForLoop:
         start = e.start.value
         step = e.step.value
         stop = self.generator.get_integer(e.stop)
-        self.values = np.arange(start, stop + step, step, dtype=np.int)
+        self.values = np.arange(start, stop + step, step, dtype=int)
         self.index_variable = _new_mx(i.name)
         self.name = i.name
         self.indexed_symbols = OrderedDict()
@@ -62,10 +62,10 @@ class ForLoop:
     def register_indexed_symbol(self, e, index_function, transpose, tree, index_expr=None):
         if isinstance(index_expr, ca.MX) and index_expr is not self.index_variable:
             F = ca.Function('index_expr', [self.index_variable], [index_expr])
-            # expr = lambda ar: np.array([F(a)[0] for a in ar], dtype=np.int)
+            # expr = lambda ar: np.array([F(a)[0] for a in ar], dtype=int)
             Fmap = F.map("map", self.generator.map_mode, len(self.values), [], [])
             res = Fmap.call([self.values])
-            indices = np.array(res[0].T, dtype=np.int)
+            indices = np.array(res[0].T, dtype=int)
         else:
             indices = self.values
         self.indexed_symbols[e] = ForLoopIndexedSymbol(tree, transpose, index_function(indices - 1))

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -1379,7 +1379,7 @@ class GenCasadiTest(unittest.TestCase):
 
         # Compare
         self.assert_model_equivalent_numeric(casadi_model, ref_model)
-        self.assertEquals(casadi_model.alg_states[0].aliases, {'alias'})
+        self.assertEqual(casadi_model.alg_states[0].aliases, {'alias'})
 
     def test_simplify_detect_negative_alias(self):
         # Create model, cache it, and load the cache

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -724,7 +724,10 @@ class GenCasadiTest(unittest.TestCase):
             ref_model = Model()
 
             def _array_mx(name, n):
-                return np.array([ca.MX.sym("{}[{}]".format(name, i+1)) for i in range(n)])
+                arr = np.empty(n, dtype=object)
+                for i in range(n):
+                    arr[i] = ca.MX.sym("{}[{}]".format(name, i+1))
+                return arr
 
             x = _array_mx("x", 3)
             y = _array_mx("y", 3)


### PR DESCRIPTION
Since version 1.20, NumPy warns about the use of np.int as an alias of
int. Instead, the suggestion is to just use `int` as the type specifier.