### PR TITLE
CasADi/Simplify: Add `resolve_parameter_values` option 

### DIFF
--- a/src/pymoca/backends/casadi/_options.py
+++ b/src/pymoca/backends/casadi/_options.py
@@ -17,6 +17,7 @@ def _get_default_options():
         'unroll_loops': True,
         'inline_functions': True,
         'expand_vectors': False,
+        'resolve_parameter_values': False,
         'replace_parameter_expressions': False,
         'replace_constant_expressions': False,
         'eliminate_constant_assignments': False,


### PR DESCRIPTION
There are few simplification options affecting parameters. These are for
example the inline parameters with symbolic values (i.e. a function of
other parameter values) into the equations they occur. That particular
simplification has a side-effect of removing the parameter after
inlining, to avoid confusion if the user wants to change its value
(which wouldn't have any effect). Sometimes however, it is useful to
have:

1. All parameter values resolved (where possible) to numeric values and
2. Have all these parameter values inlined in the min/max/etc metadata
2. Still keep the parameter names + values around

To that end, we introduce a new simplification
`resolve_parameter_values`, disabled by default.