### PR TITLE
Modelica: Add __repr__ to AST Nodes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,6 @@ James Goppert
 The CasADi backend was funded by Deltares and written by:
 Joris Gillis (Yacoda)
 Jorn Baayen (Deltares)
+
+Contributions to Modelica frontend by:
+Kent Rutan (Caterpillar Inc.)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, James Goppert
+Copyright (c) 2016-2021, James Goppert and the Pymoca contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/test/ast_test.py
+++ b/test/ast_test.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 
 from pymoca import ast
@@ -40,3 +41,31 @@ class TestASTManipulation(unittest.TestCase):
 
         self.ast.remove_equation(e)
         self.assertNotIn(e, self.ast.equations)
+
+
+class TestASTReprAndStr(unittest.TestCase):
+    def test_all_repr_and_str_len(self):
+        for attr_string in dir(ast):
+            attr = getattr(ast, attr_string)
+            if inspect.isclass(attr) and issubclass(attr, ast.Node):
+                class_instance = attr()
+                self.assertNotEqual(len(repr(class_instance)), 0)
+                if isinstance(class_instance, ast.ComponentRef):
+                    self.assertEqual(len(str(class_instance)), 0)
+                else:
+                    self.assertNotEqual(len(str(class_instance)), 0)
+
+    def test_component_ref(self):
+        cref = ast.ComponentRef.from_string('A0.B1.C2')
+
+        cref_tuple = cref.to_tuple()
+        self.assertEqual(cref_tuple[0], 'A0')
+        self.assertEqual(cref_tuple[1], 'B1')
+        self.assertEqual(cref_tuple[2], 'C2')
+
+        cref_d3 = ast.ComponentRef.from_string('D3')
+        self.assertEqual(str(cref_d3), 'D3')
+
+        cref_cat = cref.from_tuple(cref_tuple + cref_d3.to_tuple())
+        self.assertEqual(str(cref_cat), 'A0.B1.C2.D3')
+        self.assertEqual(repr(cref_cat), "'A0'['B1'['C2'['D3']]]")


### PR DESCRIPTION
Add `__repr__` to all AST `Node`'s to improve debugging.

In the process I also changed some `__str__` methods. This could break any code that depended on the prior `str()` format. In particular, the `__str__` method of `Node` itself (that is inherited by many subclasses) now tries to trim out trivial/empty attributes to make a more readable json printout. This "feature" could be reverted if necessary.

The the `ComponentRef` class method `concatenate` is changed to a regular method and now takes a single `ComponentRef` instead of a list. This does not appear to be used in any other pymoca code, but again could break other code using it. I do use it in the added AST tests, but the main reason for changing this is efficiency for an upcoming `import` addition. This could be easily reverted if necessary and/or moved to the upcoming `import` pull request.

Finally, we would like to update the AUTHORS and LICENSE files. Please propose any additions needed to the AUTHORS file.