### PR TITLE
CasADi/Simplify: Cast to Python type when substituting metadata

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -238,6 +238,17 @@ class Model:
         expressions = ca.substitute(expressions, symbols, values)
 
         for variable, attribute, value in zip(variables, attributes, expressions):
+            if variable.python_type in {int, float}:
+                if isinstance(value, ca.MX) and value.is_constant() and value.shape == (1, 1):
+                    if attribute in {"value", "start", "min", "max", "nominal"}:
+                        # Inf is common/the default for min/max. Because
+                        # integers cannot represent this value, we cast them
+                        # to floats instead.
+                        if value.is_regular():
+                            value = variable.python_type(float(value))
+                        else:
+                            value = float(value)
+
             setattr(variable, attribute, value)
 
     def _expand_vectors(self):


### PR DESCRIPTION
When substituting metadata, we prefer to end up with the type of the
corresponding Variable.

For instance, when the expression `0.25 * x ** 2` is resolved for `x =
1.0`, we would end up with a ca.MX value instead of a float. Due to
NumPy 1.20 changing the behavior around arrays [0], it is no longer
possible to "just" use this ca.MX in e.g. array expressions. This commit
makes sure that we end up with a Python float instead.

[0] See also 649e22ad