### PR TITLE
Don't build AST if parse fails

### DIFF
--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -293,8 +293,8 @@ class ParseTest(unittest.TestCase):
         with open(os.path.join(MODEL_DIR, 'RedeclareNestedClass.mo.fail_parse'), 'r') as f:
             txt = f.read()
 
-        with self.assertRaises(Exception):
-            ast_tree = parser.parse(txt)
+        ast_tree = parser.parse(txt)
+        self.assertIsNone(ast_tree)
 
     def test_extends_order(self):
         with open(os.path.join(MODEL_DIR, 'ExtendsOrder.mo'), 'r') as f:


### PR DESCRIPTION
Before this change, `parser.parse()` would continue on its merry
way trying to build an AST when there were syntax errors from ANTLR.
At the least it is wasted time.

Also fixed type errors found by mypy and in the process found that
there was a bit of duplicate code between `ASTListener` members
`ast_result` and `file_node`.