### PR TITLE
CI/CD: Fix tox issues and bump Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - run: pip install tox
@@ -35,10 +35,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - run: |
@@ -52,17 +52,17 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags') }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: |
         python -m pip install --upgrade pip
         pip install tox
     - run: tox -e coverage
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
 
@@ -72,8 +72,8 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ exclude =
 	.git,
 	.tox,
 	docs/source/conf.py,
+	test/libraries,
 	# generated files
 	__pycache__,
 	build,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 
 import os
 import subprocess
-import sys
 
 from setuptools import Command, find_packages, setup
 
@@ -44,13 +43,6 @@ Topic :: Software Development :: Embedded Systems
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 # pylint: disable=no-init, too-few-public-methods
-
-
-PYTHON_VERSION = '.'.join([str(i) for i in sys.version_info[:3]])
-PYTHON_VERSION_REQUIRED = '3.5.0'
-if PYTHON_VERSION < PYTHON_VERSION_REQUIRED:
-    sys.exit("Sorry, only Python >= {:s} is supported".format(
-        PYTHON_VERSION_REQUIRED))
 
 
 class AntlrBuildCommand(Command):
@@ -135,7 +127,7 @@ def setup_package():
         ],
         tests_require=['coverage >= 3.7.1', 'pytest', 'pytest-runner'],
         extras_require=extras_require,
-        python_requires='>=3.5',
+        python_requires='>=3.7',
         packages=find_packages("src"),
         package_dir={"": "src"},
         include_package_data=True,

--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -593,7 +593,7 @@ class Class(Node):
                 if search_imports:
                     if component_ref.name in self.imports:
                         # First search qualified imports (most common case)
-                        import_ : Union[ImportClause, ComponentRef] = self.imports[component_ref.name]
+                        import_ = self.imports[component_ref.name] # type: Union[ImportClause, ComponentRef]
                         if isinstance(import_, ImportClause):
                             # Expand short name
                             if component_ref.child:

--- a/src/pymoca/backends/xml/generator.py
+++ b/src/pymoca/backends/xml/generator.py
@@ -33,12 +33,14 @@ class XmlGenerator(TreeListener):
             op_name = tree.operator
         if len(tree.operands) == 1:
             self.xml[tree] = E(
-                'operator', name=op_name,
-                *[self.xml[c] for c in tree.operands])
+                'operator',
+                *[self.xml[c] for c in tree.operands],
+                name=op_name)
         else:
             self.xml[tree] = E(
-                'apply', builtin=op_name,
-                *[self.xml[c] for c in tree.operands])
+                'apply',
+                *[self.xml[c] for c in tree.operands],
+                builtin=op_name)
 
     def exitPrimary(self, tree: ast.Primary):
         self.xml[tree] = E('real', value=str(tree.value))
@@ -97,8 +99,8 @@ class XmlGenerator(TreeListener):
     def exitFunction(self, tree: ast.Function):
         self.xml[tree] = E(
             'apply',
-            builtin=tree.name,
-            *[self.xml[arg] for arg in tree.arguments]
+            *[self.xml[arg] for arg in tree.arguments],
+            builtin=tree.name
         )
 
     def exitWhenEquation(self, tree: ast.WhenEquation):

--- a/tools/compiler.py
+++ b/tools/compiler.py
@@ -126,7 +126,7 @@ def translate(library_ast: pymoca.ast.Tree, model: str,
         try:
             result = sympy_gen.generate(library_ast, model, options)
             outfile = outdir.joinpath(model + '.py')
-            with open(outfile, 'w') as file:
+            with outfile.open('w') as file:
                 file.write(result)
         except (IOError, OSError):
             if log.level is logging.DEBUG:
@@ -217,8 +217,8 @@ def main(argv: List[str]) -> int:
         return errors
 
     tic = time.perf_counter()
-    error_files : List[Path] = []
-    modelica_files : List[Path] = []
+    error_files = [] # type: List[Path]
+    modelica_files = [] # type: List[Path]
     if args.target == 'sympy' or not args.target:
 
         library_ast = pymoca.ast.Tree(name='ModelicaTree')

--- a/tools/create_conda_env.sh
+++ b/tools/create_conda_env.sh
@@ -12,7 +12,7 @@ conda update -q conda
 # Useful for debugging any issues with conda
 conda info -a
 conda config --add channels conda-forge
-conda create -n pymoca python=3.5 || echo "environment already created"
+conda create -n pymoca python=3.7 || echo "environment already created"
 conda install -n pymoca gcc jinja2 matplotlib numpy scipy sympy
 source activate pymoca
 # Note: casadi installed using pip since conda version currently

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    flake8,py35,py38,py39,coverage
+    flake8,py,coverage
 
 
 [testenv]


### PR DESCRIPTION
This fixes #250 which are some issues identified by tox (which I just got up and running on my machine):

- Some Python scripts in the newly-added Modelica Standard Library submodules were triggering flake8 errors, so excluded them
- Typing syntax incompatible with Python 3.5 were reverted to type comments