### PR TITLE
Tools/compiler: Fix test and True/False options

### DIFF
--- a/test/compiler_test.py
+++ b/test/compiler_test.py
@@ -112,7 +112,7 @@ class CompilerTest(unittest.TestCase):
             '-vv -Ospam=eggs',  # Flatten only, -O ignored
             '-v -tcasadi',  # -v = logging.INFO
             '-vv --target=casadi',  # -vv = logging.DEBUG
-            '-t=casadi -Ocache=True -Ocheck_balanced=False',
+            '-t=casadi -Ocache=False -Ocodegen=False -Ocheck_balanced=True',
         ]
         for args in arg_examples:
             self.run_compiler_add_model_dir(args)

--- a/tools/compiler.py
+++ b/tools/compiler.py
@@ -203,7 +203,7 @@ def main(argv: List[str]) -> int:
             optsplit = opt.split('=')
             if len(optsplit) == 2:
                 # Convert True/False values, otherwise string value as-is
-                value_lower = optsplit[1].lower
+                value_lower = optsplit[1].lower()
                 if value_lower == 'true':
                     optsplit[1] = True
                 elif value_lower == 'false':


### PR DESCRIPTION
This fixes #252 where there was a pickle version issue in CasADi model cache when switching from newer to older Python versions. This just fixes the compiler test to be more robust, not the CasADi backend.

This also fixes a related bug where "True" and "False" strings passed on the command line were not properly converted to bool, and so as non-zero length strings, they were always recognized as True.