### PR TITLE
Modelica: preserve class comments in flattening

### DIFF
--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -214,6 +214,7 @@ def flatten_extends(orig_class: Union[ast.Class, ast.InstanceClass], modificatio
     extended_orig_class = ast.InstanceClass(
         name=orig_class.name,
         type=orig_class.type,
+        comment=orig_class.comment,
         annotation=ast.ClassModification(),
         parent=parent
     )
@@ -475,6 +476,7 @@ def flatten_symbols(class_: ast.InstanceClass, instance_name='') -> ast.Class:
     flat_class = ast.Class(
         name=class_.name,
         type=class_.type,
+        comment=class_.comment,
         annotation=class_.annotation,
     )
 

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -606,5 +606,16 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(symbols['flange.phi'].displayUnit.value, 'deg')
         self.assertEqual(symbols['flange.phi'].quantity.value, 'Angle')
 
+    def test_class_comment(self):
+        """Test that class comment/description is retained after flattening"""
+        library_tree = self.parse_model_files('Aircraft.mo')
+        comp_ref = ast.ComponentRef.from_string('Aircraft')
+        flat_tree = tree.flatten(library_tree, comp_ref)
+        aircraft = flat_tree.classes['Aircraft']
+        self.assertEqual(aircraft.comment, 'the aircraft')
+        self.assertEqual(aircraft.symbols['accel.a_x'].comment, 'true acceleration')
+        self.assertEqual(aircraft.symbols['accel.ma_x'].comment, 'measured acceleration')
+        self.assertEqual(aircraft.symbols['body.g'].comment, '')
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Class comments (class "description" in Modelica Spec 3.5 grammar) should be retained during flattening because they are quite helpful in describing the purpose of the class to humans and therefore backends should have access through the AST. Previously comments were dropped.