### PR TITLE
Modelica: Add initial equation add/remove methods

### DIFF
--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -773,6 +773,22 @@ class Class(Node):
         """
         self.equations.remove(e)
 
+    def add_initial_equation(self, e: Equation) -> None:
+        """
+        Add an initial equation to this class.
+
+        :param e: Equation to add.
+        """
+        self.initial_equations.append(e)
+
+    def remove_initial_equation(self, e: Equation) -> None:
+        """
+        Removes an initial equation from this class.
+
+        :param e: Equation to remove.
+        """
+        self.initial_equations.remove(e)
+
     def __deepcopy__(self, memo):
         # Avoid copying the entire tree
         if self.parent is not None and self.parent not in memo:

--- a/src/pymoca/parser.py
+++ b/src/pymoca/parser.py
@@ -179,10 +179,7 @@ class ASTListener(ModelicaListener):
 
     def exitEquation_section(self, ctx: ModelicaParser.Equation_sectionContext):
         eq_sect = self.ast[ctx]
-        if eq_sect.initial:
-            eq_sect.equations.extend(self.ast[ctx.equation_block()])
-        else:
-            eq_sect.equations.extend(self.ast[ctx.equation_block()])
+        eq_sect.equations.extend(self.ast[ctx.equation_block()])
 
     def exitEquation_block(self, ctx: ModelicaParser.Equation_blockContext):
         self.ast[ctx] = [self.ast[e] for e in ctx.equation()]
@@ -199,10 +196,7 @@ class ASTListener(ModelicaListener):
 
     def exitAlgorithm_section(self, ctx: ModelicaParser.Algorithm_sectionContext):
         alg_sect = self.ast[ctx]
-        if alg_sect.initial:
-            alg_sect.statements.extend(self.ast[ctx.statement_block()])
-        else:
-            alg_sect.statements.extend(self.ast[ctx.statement_block()])
+        alg_sect.statements.extend(self.ast[ctx.statement_block()])
 
     # EQUATION ===========================================================
 

--- a/test/ast_test.py
+++ b/test/ast_test.py
@@ -42,6 +42,12 @@ class TestASTManipulation(unittest.TestCase):
         self.ast.remove_equation(e)
         self.assertNotIn(e, self.ast.equations)
 
+        self.ast.add_initial_equation(e)
+        self.assertIn(e, self.ast.initial_equations)
+
+        self.ast.remove_initial_equation(e)
+        self.assertNotIn(e, self.ast.initial_equations)
+
 
 class TestASTReprAndStr(unittest.TestCase):
     def test_all_repr_and_str_len(self):


### PR DESCRIPTION
Adds methods to `ast.Class` to add/remove initial equations (as regular equations have). These can be useful in backend code to convert start attributes to initial equations. Also cleans up related superfluous code in the parser callbacks.

Tests that intitial equations are correctly parsed and new add/remove methods work correctly. This somewhat duplicates CasADi initial condition tests, but using a ModelicaCompliance example.