### PR TITLE
setup.py: Fix Jinja2 dependency for SymPy backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ def setup_package():
         'sympy': [
             'sympy >= 0.7.6.1',
             'scipy >= 0.13.3',
+            'jinja2 >= 2.10.1',
         ],
         # Examples
         'examples': [


### PR DESCRIPTION
Jinja2 is an explicit dependency of the SymPy backend, yet was not listed. The minimal version requirement added is that of when the "import jinja2" line was added, i.e. around May 2017.

Note that the lack of this listing does not usually lead to issues, because Jinja2 is installed as part of JupyterLab. JupyterLab is a dependency for the "examples" extra, and therefore also part of the "all" extra that is used by the CI/CD pipeline.