### PR TITLE
Tree: Fix scoping of inherited symbols

### DIFF
--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -399,6 +399,7 @@ class Symbol(Node):
         self.order = 0  # type: int
         self.visibility = Visibility.PRIVATE  # type: Visibility
         self.class_modification = None  # type: ClassModification
+        self.parent = None # type: Class
         super().__init__(**kwargs)
 
     def __str__(self):

--- a/src/pymoca/parser.py
+++ b/src/pymoca/parser.py
@@ -637,14 +637,14 @@ class ASTListener(ModelicaListener):
             s.type = copy.deepcopy(clause.type)
 
     def enterComponent_declaration(self, ctx: ModelicaParser.Component_declarationContext):
-        sym = ast.Symbol(order=self.sym_count)
+        sym = ast.Symbol(order=self.sym_count, parent=self.class_node)
         self.sym_count += 1
         self.ast[ctx] = sym
         self.symbol_node = sym
         self.comp_clause.symbol_list += [sym]
 
     def enterComponent_declaration1(self, ctx: ModelicaParser.Component_declaration1Context):
-        sym = ast.Symbol(order=self.sym_count)
+        sym = ast.Symbol(order=self.sym_count, parent=self.class_node)
         self.sym_count += 1
         self.ast[ctx] = sym
         self.symbol_node = sym
@@ -654,7 +654,7 @@ class ASTListener(ModelicaListener):
         if self.symbol_node is not None:
             self.ast[ctx] = self.symbol_node
         else:
-            sym = ast.Symbol(order=self.sym_count)
+            sym = ast.Symbol(order=self.sym_count, parent=self.class_node)
             self.sym_count += 1
             self.ast[ctx] = sym
             self.symbol_node = sym

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -161,7 +161,7 @@ class TreeWalker:
         endless recursion by skipping references to e.g. parent nodes.
         :return: True if child needs to be skipped, False otherwise.
         """
-        if isinstance(tree, ast.Class) and child_name == 'parent' or \
+        if isinstance(tree, (ast.Class, ast.Symbol)) and child_name == 'parent' or \
                 isinstance(tree, ast.ClassModificationArgument) and child_name in ('scope', '__deepcopy__'):
             return True
         return False
@@ -366,7 +366,11 @@ def build_instance_tree(orig_class: Union[ast.Class, ast.InstanceClass], modific
 
         try:
             if not isinstance(sym.type, ast.InstanceClass):
-                c = extended_orig_class.find_class(sym.type)
+                try:
+                    c = extended_orig_class.find_class(sym.type)
+                except ast.ClassNotFoundError:
+                    # If not found in local scope, search in original scope
+                    c = sym.parent.find_class(sym.type)
             else:
                 c = sym.type
         except ast.FoundElementaryClassError:

--- a/test/models/InheritanceInstantiationResistor.mo
+++ b/test/models/InheritanceInstantiationResistor.mo
@@ -1,0 +1,27 @@
+// Example to test inherited name lookup with a case similar to MSL v4
+// Modelica.Electrical.Analog.Basic.Resistor where the symbol type name
+// PositivePin is referenced in an inheritance hierarchy two levels deep.
+// It also tests modifying something other than value.
+package P
+  package T
+    class Voltage = Real(nominal=1);
+  end T;
+  package I
+    class Level1
+      // i.e. OnePort
+      extends Level2(p.v(nominal=10), n.v(nominal=10));
+    end Level1;
+    class Level2
+      // i.e. TwoPin
+      Level3 p(v(nominal=20)), n(v(nominal=20));
+    end Level2;
+    class Level3
+      // i.e. PostitivePin
+      T.Voltage v(nominal=30);
+    end Level3;
+  end I;
+  model M
+    // i.e. Resistor
+    extends I.Level1(p.v(nominal=0), n.v(nominal=0));
+  end M;
+end P;

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -138,6 +138,15 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(flat_tree.classes['C2'].symbols['bcomp3.a'].value.value, 1.0)
         self.assertEqual(flat_tree.classes['C2'].symbols['bcomp3.b'].value.value, 2.0)
 
+    def test_inheritance_resistor(self):
+        with open(os.path.join(MODEL_DIR, 'InheritanceInstantiationResistor.mo'), 'r') as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef.from_string('P.M'))
+
+        self.assertEqual(flat_tree.classes['P.M'].symbols['p.v'].nominal.value, 0.0)
+        self.assertEqual(flat_tree.classes['P.M'].symbols['n.v'].nominal.value, 0.0)
+
     def test_nested_classes(self):
         with open(os.path.join(MODEL_DIR, 'NestedClasses.mo'), 'r') as f:
             txt = f.read()


### PR DESCRIPTION
This fixes cases where inherited symbol type lookup fails because the scope of the type was lost during instantiation.  One example where it fails is in flattening MSL 4 `Modelica.Electrical.Analog.Basic.Resistor` where the symbol type name `PositivePin` is referenced in an inheritance hierarchy two levels deep.

See Modelica Language Spec 3.5 section 5.6.1.2 and related sections.

This implementation adds a parent attribute to the `ast.Symbol` class that is set during creation of the AST. If local lookup fails, the original symbol parent is then used as the starting point for symbol type lookup in `tree.build_instance_tree()`.

A test case is added that is similar to MSL 4 Resistor that failed.