### PR TITLE
Draft: Disable reverse() codegen

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -148,7 +148,7 @@ def _codegen_model(model_folder: str, f: ca.Function, library_name: str):
     cg = ca.CodeGenerator(library_name)
     cg.add(f, True) # Nondifferentiated function
     cg.add(f.forward(1), True) # Jacobian-times-vector product
-    cg.add(f.reverse(1), True) # vector-times-Jacobian product
+    # cg.add(f.reverse(1), True) # vector-times-Jacobian product
     cg.add(f.reverse(1).forward(1), True) # Hessian-times-vector product
     cg.generate(model_folder + '/')
 


### PR DESCRIPTION
The Casadi error for the .reverse() line is:

```
src\pymoca\backends\casadi\api.py:482: in transfer_model
    save_model(model_folder, model_name, model, compiler_options)
src\pymoca\backends\casadi\api.py:197: in save_model
    objects[o] = _codegen_model(model_folder, f, '{}_{}'.format(model_name, o))
src\pymoca\backends\casadi\api.py:151: in _codegen_model
    cg.add(f.reverse(1), True) # vector-times-Jacobian product
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <casadi.casadi.CodeGenerator; proxy of <Swig Object of type 'casadi::CodeGenerator *' at 0x00000271700A7120> >
args = (Function(adj1_dae_residual:(in_i0,in_i1[2],in_i2[2],in_i3[6],in_i4[0],in_i5[0],in_i6[4],out_o0[8x1,0nz],adj_o0[8])->(adj_i0[1x1,0nz],adj_i1[2x1,1nz],adj_i2[2],adj_i3[6],adj_i4[0],adj_i5[0],adj_i6[4x1,2nz]) MXFunction), True)

    def add(self, *args) -> "void":
        """
          [INTERNAL]

        ::

          add(self, Function f, bool with_jac_sparsity)

        Add a function (name generated)

        Doc source:
        https://github.com/casadi/casadi/blob/develop/casadi/core/code_generator.hpp#L49

        Implementation:
        https://github.com/casadi/casadi/blob/develop/casadi/core/code_generator.cpp#L276-L301




        """
>       return _casadi.CodeGenerator_add(self, *args)
E       RuntimeError: Error in Function::jac_sparsity for 'adj1_dae_residual' [MXFunction] at .../casadi/core/function.cpp:915:
E       .../casadi/core/sparsity_internal.cpp:2370: Assertion "size2()==y.size2() && size1()==y.size1()" failed:
E       Dimension mismatch : [0,1] versus [1,0].

..\venv\lib\site-packages\casadi\casadi.py:33529: RuntimeError
```