### PR TITLE
SymPy: Fix generator duplicate variable creation

### DIFF
--- a/src/pymoca/backends/sympy/generator.py
+++ b/src/pymoca/backends/sympy/generator.py
@@ -138,9 +138,6 @@ class {{tree.name}}(OdeModel):
             {% endfor -%}}
 
         # outputs
-        {% if outputs_str|length > 0 -%}
-        {{ outputs_str }} = mech.dynamicsymbols('{{ outputs_str|replace('__', '.') }}')
-        {% endif -%}
         self.y = sympy.Matrix([{{ outputs_str }}])
 
         # equations

--- a/src/pymoca/backends/sympy/runtime.py
+++ b/src/pymoca/backends/sympy/runtime.py
@@ -34,7 +34,7 @@ class OdeModel:
         if n_states + n_vars != n_eqs:
             raise RuntimeError('# states: {:d} + # variables: {:d} != # equations {:d}'.format(
                 n_states, n_vars, n_eqs))
-        lhs = list(self.x.diff(self.t)) + list(self.v) + list(self.y)
+        lhs = list(self.x.diff(self.t)) + list(self.v)
         fg_sol = sympy.solve(self.eqs, lhs, dict=True)[0]
         self.f = self.x.diff(self.t).subs(fg_sol)
         assert len(self.x) == len(self.f)


### PR DESCRIPTION
Removes duplicate SymPy symbols that the sympy generator backend creates for Modelica output variables. They are already created in the variables section of the Jinja template.

SymPy 1.12 aparently added a check for duplicate symbols. SymPy throws a `ValueError: duplicate symbols given` exception in `sympy.solve()` that causes `test_estimator` in `gen_sympy_test` to fail.