### PR TITLE
Bump Python >= 3.8 and test to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.11"
       - run: pip install tox
       - run: tox -e flake8
 
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
         submodules: true
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.11"
     - run: |
         python -m pip install --upgrade pip
         pip install tox
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.11"
     - run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ def setup_package():
         ],
         tests_require=['coverage >= 3.7.1', 'pytest', 'pytest-runner'],
         extras_require=extras_require,
-        python_requires='>=3.7',
+        python_requires='>=3.8',
         packages=find_packages("src"),
         package_dir={"": "src"},
         include_package_data=True,


### PR DESCRIPTION
Python 3.7 is EOL.

Also, the recent CasADi 3.6.3 release supports Python up to 3.11. Since we do not pin the max Python and CasADi versions, we need to test up to Python 3.11.