### PR TITLE
CI/CD: Add GitHub release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,8 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
+    - uses: softprops/action-gh-release@v1
+      with:
+        files: dist/*
+        generate_release_notes: true
+        


### PR DESCRIPTION
This adds an action to create a GitHub release after the PyPI release actions so that the repo will reflect the release on PyPI. 

It has not been tested since I don't know how to do that without going live.

EDIT
I should probably add that there is an [Official PyPA release action](https://github.com/marketplace/actions/pypi-publish) that might be good to look at for future updates to the CD. See, for instance, the [flask publish workflow](https://github.com/pallets/flask/blob/main/.github/workflows/publish.yaml) which also creates a GitHub release using a more manual method than the action I used in this PR.