### PR TITLE
CI/CD: Add GitHub release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,8 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
+    - uses: softprops/action-gh-release@v1
+      with:
+        files: dist/*
+        generate_release_notes: true
+        


### PR DESCRIPTION
This adds a GitHub release action to track along with the PyPI releases.

It uses `softprops/action-gh-release` which is 1 of 4 actions recommended by the now archived GitHub-developed action
[`actions/create-release`](https://github.com/actions/create-release) and has the most stars and contributors of the 4.

The flag is turned on to auto-generate GitHub release notes to keep maintenance to a minimum while Pymoca is at its current level of development. I expect we will want to have some human intervention in creating release notes as we get closer to the 1.0 milestone and it looks very doable to gradually add more of that along with the auto-generated content. You can check out the auto-generated notes in the 0.10.0.dev6 release while this PR is being reviewed, but I intend to delete that release when the official 0.10.0 release is tagged so it will include the notes.

On the subject of releasing, there is an [official PyPA release action](https://github.com/marketplace/actions/pypi-publish) for uploading PyPI distributions with the recommended "trusted publishing" instead of the token-based authentication currently used. I can't make that change with my current level of permissions.

This replaces #277 from my fork so I could properly test the actions in the repo vs my fork.