### PR TITLE
CasADi/Simplify: Fix `resolve_parameter_values` for list/array values

### DIFF
--- a/src/pymoca/backends/casadi/model.py
+++ b/src/pymoca/backends/casadi/model.py
@@ -491,7 +491,7 @@ class Model:
                 next_parameters_and_constants = []
 
                 for p in current_parameters_and_constants:
-                    if isinstance(p.value, list):
+                    if isinstance(p.value, (list, np.ndarray)):
                         p.value = np.array(p.value)
 
                         if not np.issubdtype(p.value.dtype, np.number):
@@ -501,7 +501,7 @@ class Model:
 
                         if not np.any(np.isnan(p.value)):
                             symbols.append(p.symbol)
-                            values.append(value)
+                            values.append(p.value)
                     else:
                         value = ca.MX(p.value)
                         if value.is_constant() and value.is_regular():


### PR DESCRIPTION
The symbol "value" was not instantiated when the parameter value was a list.

Furthermore, we were only looking at lists and not also at NumPy arrays. We force convert from list to array in this if-branch, and also in some places in the code. We therefore have to make sure the condition catches both lists and np.ndarrays.