### PR TITLE
Style: Use pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     - cron: "6 6 * * 3"
 
 jobs:
-  style-flake8:
+  pre-commit:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,22 +21,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: pip install tox
-      - run: tox -e flake8
-
-  style-black:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - run: pip install tox
-      - run: tox -e black
+      - uses: pre-commit/action@v3.0.0
 
   test:
-    needs: [style-flake8, style-black]
+    needs: pre-commit
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -98,4 +86,4 @@ jobs:
       with:
         files: dist/*
         generate_release_notes: true
-        
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
+    hooks:
+      - id: black
+        args: [--check, --diff]
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        # TODO: Commenting out max supported Python version until we pin it for Pymoca
+        # language_version: python3.11
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          [flake8-bugbear, flake8-comprehensions, flake8-import-order]
+        # This exclude list should be same as for black in pyproject.toml
+        # See https://pre-commit.com/#regular-expressions for this syntax
+        exclude: |
+          (?x)^(
+            src/pymoca/generated/.*|
+            src/pymoca/_version.py|
+            test/generated/.*|
+            test/libraries/.*
+          )$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ parentdir_prefix = "pymoca-"
 [tool.black]
 line-length = 100
 target-version = ['py38', 'py39', 'py310', 'py311']
-exclude = '''
+force-exclude = '''
 	(
 		  src/pymoca/generated
 		| src/pymoca/_version.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    flake8,py,coverage
+    py,coverage
 
 
 [testenv]
@@ -17,22 +17,3 @@ deps =
 passenv = GITHUB_ACTIONS
 commands =
     pytest --cov --cov-report=xml test {posargs}
-
-
-[testenv:flake8]
-skip_install = true
-application-import-names = pymoca,test
-deps =
-  flake8
-  flake8-bugbear
-  flake8-comprehensions
-  flake8-import-order
-commands = flake8 src test tools setup.py
-
-
-[testenv:black]
-skip_install = True
-deps =
-    black >= 23.7.0
-commands =
-    black --check --diff src test tools setup.py


### PR DESCRIPTION
Wanted something to automatically check for style conformance before pushing to GitHub and the [pre-commit Python package](https://pypi.org/project/pre-commit/) seems to do the trick.

In addition, since there are GitHub actions for pre-commit, I propose changing the CI to use pre-commit also so local and GitHub configuration for style checks are consistent and in once place. This is the 2nd commit in this PR, so it can be dropped if we decide not to do that.

If we adopt for GitHub CI, there is a [pre-commit GitHub action](https://github.com/marketplace/actions/pre-commit) and there is also a separate [pre-commit CI service](https://pre-commit.ci) that says it is free for open source.