### PR TITLE
Tree: Fix inherited type value modification

### DIFF
--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -427,9 +427,12 @@ def build_instance_tree(
 
     # Check that all symbol modifications to be applied on this class exist
     for arg in extended_orig_class.modification_environment.arguments:
-        if arg.value.component.name not in extended_orig_class.symbols:
+        if (
+            arg.value.component.name not in extended_orig_class.symbols
+            and arg.value.component.name not in ast.Symbol.ATTRIBUTES
+        ):
             raise ModificationTargetNotFound(
-                "Trying to modify symbol {}, which does not exist in class {}".format(
+                'Trying to modify symbol "{}", which does not exist in class {}'.format(
                     arg.value.component.name, extended_orig_class.full_reference()
                 )
             )
@@ -450,6 +453,8 @@ def build_instance_tree(
                 for x in extended_orig_class.modification_environment.arguments
                 if isinstance(x.value, ast.ElementModification)
                 and x.value.component.name == sym_name
+                or sym_name == "__value"
+                and x.value.component.name == "value"
             ]
 
             # Remove from current class's modification environment
@@ -551,7 +556,7 @@ def build_instance_tree(
                 sym.type = build_instance_tree(c, sym.class_modification, c.parent)
             except Exception as e:
                 error_sym = str(orig_class.full_reference()) + "." + sym_name
-                raise type(e)('Processing failed for symbol "{}"'.format(error_sym)) from e
+                raise type(e)('Processing failed for symbol "{}":\n{}'.format(error_sym, e)) from e
 
             sym.class_modification = None
 


### PR DESCRIPTION
This fixes a problem where modifying the value of a symbol of a type that is inherited from another type would fail during instantiation with a `pymoca.tree.ModificationTargetNotFound`.

This also expands the "Processing failed for symbol" message given when symbol type instantiation fails in `build_instance_tree`. It now includes the message from the underlying exception to give a more specific reason for the failure.

This is related to 4dd9048 that fixed inherited types for two test cases using SI units in MSL 3 and 4, but they did not include testing value *modification* of the inherited types.

Closes #300.