### PR TITLE
Tree: Fix storing constant references in non-elementary typed equations

### DIFF
--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -250,6 +250,20 @@ class AttributeRef(ComponentRef):
         super().__init__(name=component_ref.name)
 
 
+class ForLoopIndexRef(ComponentRef):
+    def __init__(self, component_ref: ComponentRef):
+        # TODO:
+        # Had to disable checks, because we also loop over annotations where
+        # other things than "value/nominal/..." are referenced
+        # assert len(component_ref.child) == 0
+        # if component_ref.name not in Symbol.ATTRIBUTES:
+        #     a = 1
+        # assert component_ref.name in Symbol.ATTRIBUTES
+        # assert component_ref.indices == [[None]]
+
+        super().__init__(name=component_ref.name)
+
+
 class SymbolTypeRef(ComponentRef):
     def __init__(self, component_ref: ComponentRef):
         assert len(component_ref.child) == 0

--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -829,7 +829,7 @@ class Class(Node):
 
                 # Found a symbol. Continue lookup on type of this symbol.
                 if isinstance(s.type, InstanceClass):
-                    return s.type._find_symbol(ComponentRef.from_tuple(t[1:]), False)
+                    return s.type._find_symbol(ComponentRef.from_tuple(t[1:]), False, in_original_scope)
                 elif isinstance(s.type, ComponentRef):
                     node = self._find_class(s.type)  # Parent lookups is OK here.
                     return node._find_symbol(ComponentRef.from_tuple(t[1:]), False)

--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -852,6 +852,20 @@ class Class(Node):
                     else:
                         raise NonConstantSymbolFoundError(f"Symbol '{component_ref}' found in enclosing scope, but is not a constant.")                   
             except KeyError:
+                # Try imports
+                if "*" in self.imports:
+                    for package_ref in self.imports["*"].components:
+                        imported_comp_ref_class = package_ref
+                        try:
+                            c = self._find_class(imported_comp_ref_class)
+                            sym = c.find_symbol(component_ref)
+                            if "constant" in sym.prefixes:
+                                return sym
+                            else:
+                                raise NonConstantSymbolFoundError(f"Symbol '{component_ref}' found in imports, but is not a constant.")
+                        except (KeyError, ClassNotFoundError):
+                            pass
+
                 if search_parent and self.parent is not None:
                     return self.parent._find_symbol(component_ref)
                 else:

--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -248,7 +248,7 @@ class AttributeRef(ComponentRef):
 class SymbolTypeRef(ComponentRef):
     def __init__(self, component_ref: ComponentRef):
         assert len(component_ref.child) == 0
-        assert component_ref.name == "Real"
+        assert component_ref.name in Class.BUILTIN
         assert component_ref.indices == [[None]]
 
         super().__init__(name=component_ref.name)

--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -238,9 +238,14 @@ class ComponentRef(Node):
 
 class AttributeRef(ComponentRef):
     def __init__(self, component_ref: ComponentRef):
-        assert len(component_ref.child) == 0
-        assert component_ref.name in Symbol.ATTRIBUTES
-        assert component_ref.indices == [[None]]
+        # TODO:
+        # Had to disable checks, because we also loop over annotations where
+        # other things than "value/nominal/..." are referenced
+        # assert len(component_ref.child) == 0
+        # if component_ref.name not in Symbol.ATTRIBUTES:
+        #     a = 1
+        # assert component_ref.name in Symbol.ATTRIBUTES
+        # assert component_ref.indices == [[None]]
 
         super().__init__(name=component_ref.name)
 

--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -1041,6 +1041,8 @@ class Tree(Class):
     The root class.
     """
 
+    # TODO: Where do we check if the number and type of arguments is correct?
+    # What does OMC do on this front?
     BUILTIN_FUNCTIONS = {
         # See Modelica Specification:
         # Section 3.7 Built-in Intrinsic Operators with Function Syntax
@@ -1097,6 +1099,39 @@ class Tree(Class):
         "edge",
         "change",
         "reinit",
+
+        #
+        # Built-in Array Functions
+        #
+        "promote",
+
+        # Dimension and Size Functions
+        "ndims",
+        "size",
+        # Dimensionality Conversion Functions
+        "scalar",
+        "vector",
+        "matrix",
+        # Specialized Array Constructor Functions
+        "identity",
+        "diagonal",
+        "zeros",
+        "ones",
+        "fill",
+        "linspace",
+        # Reduction Functions and Operators
+        "min",
+        "max",
+        "sum",
+        "product",
+        # Matrix and Vector Algebra Functions
+        "transpose",
+        "outerProduct",
+        "symmetric",
+        "cross",
+        "skew",
+        # TODO: Where does this one belong?
+        "cat",
     }
 
     def __init__(self, *args, **kwargs):

--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -853,6 +853,7 @@ class Class(Node):
                         raise NonConstantSymbolFoundError(f"Symbol '{component_ref}' found in enclosing scope, but is not a constant.")                   
             except KeyError:
                 # Try imports
+                # TODO: Prettyify, bit of duplicate code between if and elif branches
                 if "*" in self.imports:
                     for package_ref in self.imports["*"].components:
                         imported_comp_ref_class = package_ref
@@ -865,6 +866,16 @@ class Class(Node):
                                 raise NonConstantSymbolFoundError(f"Symbol '{component_ref}' found in imports, but is not a constant.")
                         except (KeyError, ClassNotFoundError):
                             pass
+                elif component_ref.name in self.imports:
+                    # TODO: Probably need some test cases to cover the
+                    # ImportClause etc stuff in the similar code in find_class
+                    # and implement the same logic here if needed (not sure yet, it being in find_class might be good enough).
+                    sym = self.find_symbol(self.imports[component_ref.name])
+                    if "constant" in sym.prefixes:
+                        return sym
+                    else:
+                        raise NonConstantSymbolFoundError(
+                            f"Symbol '{component_ref}' found in imports, but is not a constant.")
 
                 if search_parent and self.parent is not None:
                     return self.parent._find_symbol(component_ref)

--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -677,6 +677,7 @@ class ExtendsClause(Node):
 
 
 class Class(Node):
+    # TODO: This really should be a set as well, we only ever do "is in"
     BUILTIN = ("Real", "Integer", "String", "Boolean")
 
     def __init__(self, **kwargs):
@@ -1039,6 +1040,69 @@ class Tree(Class):
     """
     The root class.
     """
+
+    BUILTIN_FUNCTIONS = {
+        # See Modelica Specification:
+        # Section 3.7 Built-in Intrinsic Operators with Function Syntax
+
+        # Numeric Functions and Conversion Functions
+        "abs",
+        "sign",
+        "sqrt"
+        "Integer",
+        "EnumTypeName",
+        "String",
+
+        # Event Triggering Mathematical Functions
+        "div",
+        "mod",
+        "rem",
+        "ceil",
+        "floor",
+        "integer",
+
+        # Elementary Mathematical Functions
+        "sin",
+        "cos",
+        "tan",
+        "asin",
+        "acos",
+        "atan",
+        "atan2",
+        "sinh",
+        "cosh",
+        "tanh",
+        "exp",
+        "log",
+        "log10",
+
+        # Derivative and Special Purpose Operators with Function Syntax
+        "der",
+        "delay",
+        "cardinality",
+        "homotopy",
+        "semiLinear",
+        "inStream",
+        "actualStream",
+        "spatialDistribution",
+        "getInstanceName",
+
+        # Event-Related Operators with Function Syntax
+        "initial",
+        "terminal",
+        "noEvent",
+        "smooth",
+        "sample",
+        "pre",
+        "edge",
+        "change",
+        "reinit",
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for f in self.BUILTIN_FUNCTIONS:
+            self.classes[f] = Class(name=f, type="function", parent=self)
 
     def extend(self, other: "Tree") -> None:
         self._extend(other)

--- a/src/pymoca/parser.py
+++ b/src/pymoca/parser.py
@@ -676,6 +676,7 @@ class ASTListener(ModelicaListener):
         sym.dimensions = dimensions
         sym.prefixes = self.comp_clause.prefixes
         sym.type = self.comp_clause.type
+        sym._parent = self.class_node
 
         # Declarations can also occur in extends clauses, in which case we do not have to add it to the class's symbols.
         if not self.in_extends_clause:

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -997,7 +997,8 @@ class ConstantReferencePuller(TreeListener):
         if not self.skip_children_of:
             sym = tree._resolved_symbol.symbol
 
-            if sym not in self.symbols and sym not in self.extra_constants:
+            # TODO: Pull functions?
+            if sym not in self.symbols and sym not in self.extra_constants and sym.type != "function":
                 sym.name = str(sym.full_reference())
 
                 self.extra_constants.add(sym)

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -332,6 +332,15 @@ def flatten_extends(
 
             sym._parent = extended_orig_class
 
+    # Resolve non-elementary symbol types from ast.ComponentRef to an ast.Class reference
+    for sym_name, sym in orig_class.symbols.items():
+        if isinstance(sym.type, ast.ComponentRef):
+            try:
+                sym.type = orig_class.find_class(sym.type)
+            except ast.FoundElementaryClassError:
+                # We will handle these later when building the instance tree
+                pass
+
     extended_orig_class.imports.update(orig_class.imports)
     extended_orig_class.classes.update(orig_class.classes)
     extended_orig_class.symbols.update(orig_class.symbols)
@@ -466,7 +475,7 @@ def build_instance_tree(
         class_name = sym.type
 
         try:
-            if not isinstance(sym.type, ast.InstanceClass):
+            if not isinstance(sym.type, ast.Class):
                 c = extended_orig_class.find_class(sym.type)
             else:
                 c = sym.type

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -993,9 +993,15 @@ class ConstantReferencePuller(TreeListener):
         self.skip_children_of = []
         super().__init__()
 
+        self.bladiebla = []
+
     def enterComponentRef(self, tree: ast.ComponentRef):
         if not self.skip_children_of:
-            sym = tree._resolved_symbol.symbol
+            try:
+                sym = tree._resolved_symbol.symbol
+            except Exception as e:
+                a = 1
+                raise
 
             # TODO: Pull functions?
             if sym not in self.symbols and sym not in self.extra_constants and sym.type != "function":
@@ -1014,6 +1020,12 @@ class ConstantReferencePuller(TreeListener):
 
     def exitClass(self, tree: ast.Class) -> None:
         tree.symbols.update({c.name: c for c in self.extra_constants})
+
+    def enterEvery(self, tree: ast.Node):
+        self.bladiebla.append(tree)
+
+    def exitEvery(self, tree: ast.Node):
+        self.bladiebla.pop()
 
 
 def pull_constant_references(flat_class: ast.Class) -> None:

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -301,6 +301,7 @@ def flatten_extends(
                 )
             extended_orig_class.type = c.type
 
+        apply_scope(extended_orig_class, extends.class_modification)
         c = flatten_extends(c, extends.class_modification, parent=c.parent)
 
         # Imports are not inherited (spec 3.5 sections 5.3.1 and 7.1)

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -726,7 +726,10 @@ class ComponentRefToSymbolRef:
     def enterComponentRef(self, tree: ast.ComponentRef):
         # HACK: Already worked around the AttributeRef thing, but now also a type is a ComponentRef... everything is a ComponentRef,
         # but they're not all equal. Can we handle them differently in the parser, that way we can also handle them easily differently here.
-        if not self.skip_children_of:
+        if not self.skip_children_of and tree._resolved_symbol is None:
+            # TODO: How come sometimes we have already resolved the symbol? E.g. with the "ExtendsModification" test case,
+            # we get "not found" error when we've already found it before (if we leave the `and tree._resolved_symbol` out of the above condition).
+            # Why does this happen?
             if self.scope is not None:
                 # Inside a passed-along modification
                 scope = self.scope

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -963,8 +963,9 @@ class ConstantReferenceApplier(TreeListener):
 
     def exitInstanceClass(self, tree: ast.InstanceClass):
         c = self.classes.pop()
-        syms = self.extra_symbols.pop()
-        c.symbols.update(syms)
+        if c.type != "__builtin":
+            syms = self.extra_symbols.pop()
+            c.symbols.update(syms)
 
     def enterClass(self, tree: ast.InstanceClass):
         raise AssertionError("All classes should have been replaced by instance classes.")

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -793,6 +793,8 @@ class ComponentRefToSymbolRef:
                 tree._resolved_symbol = ForIndexReference(tree.name)
                 return
 
+            # NOTE: User-defined symbols/functions/etc take precedence over built-in functions.
+
             # TODO: How come sometimes we have already resolved the symbol? E.g. with the "ExtendsModification" test case,
             # we get "not found" error when we've already found it before (if we leave the `and tree._resolved_symbol` out of the above condition).
             # Why does this happen?

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -388,7 +388,7 @@ def build_instance_tree(
         argument = class_mod_argument.value
         if isinstance(argument, ast.ShortClassDefinition):
             old_class = extended_orig_class.classes[argument.name]
-            extended_orig_class.classes[argument.name] = scope_class.find_class(argument.component)
+            extended_orig_class.classes[argument.name] = scope_class.find_class(argument.component, copy=False)
 
             # Fix references to symbol types that were already in the instance tree
             for sym in extended_orig_class.symbols.values():
@@ -761,7 +761,7 @@ def resolve_component_references_to_symbols(class_: ast.InstanceClass) -> None:
 
 class ComponentRefFlattener(TreeListener):
 
-    def __init__(self, class_: ast.InstanceClass):
+    def __init__(self, class_: ast.Class):
         self.class_ = class_
         self.symbols = set(class_.symbols.values())
         self.bladiebla = []
@@ -785,7 +785,7 @@ class ComponentRefFlattener(TreeListener):
 
         a = 1
 
-def flatten_component_refs(class_: ast.InstanceClass) -> None:
+def flatten_component_refs(class_: ast.Class) -> None:
     w = TreeWalker()
     w.walk(ComponentRefFlattener(class_), class_)
 

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -682,6 +682,10 @@ class SymbolReference:
 
 
 class ComponentRefToSymbolRef:
+    # TODO:
+    # Ugh, I only really want to look up symbols...
+    # But with everything being ComponentRefs, how do I know if it's a Symbol reference or some
+    # other thing lke an Import clause, class reference, what have you.
 
     def __init__(self, class_):
         self.instance_class = []
@@ -702,9 +706,9 @@ class ComponentRefToSymbolRef:
     def enterSymbol(self, tree: ast.Symbol) -> None:
         if isinstance(tree.type, ast.ComponentRef):
             tree.type = ast.SymbolTypeRef(tree.type)
-    
-    def enterSymbolReference(self, tree: SymbolReference) -> None:
-        a = 1
+
+    def enterImportClause(self, tree: SymbolReference) -> None:
+        self.skip_children_of.append(tree)
 
     def enterClassModificationArgument(self, tree: ast.ClassModificationArgument) -> None:
         self.scope = tree.scope
@@ -735,10 +739,6 @@ class ComponentRefToSymbolRef:
             if tree.child:
                 self.skip_children_of.append(tree)
             
-    def exitComponentRef(self, tree: ast.ComponentRef) -> None:
-        if self.skip_children_of and tree is self.skip_children_of[-1]:
-            self.skip_children_of.pop()
-   
     def exitClassModificationArgument(self, tree: ast.ClassModificationArgument):
         self.scope = None
         self.modification.pop()
@@ -750,6 +750,9 @@ class ComponentRefToSymbolRef:
         self.bladiebla.append(tree)
 
     def exitEvery(self, tree: ast.Node):
+        if self.skip_children_of and tree is self.skip_children_of[-1]:
+            self.skip_children_of.pop()
+
         self.bladiebla.pop()
 
 

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -218,7 +218,7 @@ class TreeWalker:
         :return: True if child needs to be skipped, False otherwise.
         """
         if (
-            (isinstance(tree, ast.Class) and child_name == "parent")
+            (isinstance(tree, ast.Class) and child_name in {"parent", "annotation"})
             or (
                 isinstance(tree, ast.ClassModificationArgument)
                 and child_name in {"scope", "__deepcopy__"}

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -956,6 +956,10 @@ class ConstantReferenceApplier(TreeListener):
             # Already inside a component reference. Do not perform lookups.
             return
 
+        if not self.scope:
+            # Not in a class modification argument
+            return
+
         if tree.child:
             try:
                 self.extra_symbols[self.scope[-1]][str(tree)] = self.scope[-1].find_constant_symbol(

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -676,6 +676,18 @@ def flatten_symbols(class_: ast.InstanceClass, instance_name="") -> ast.Class:
                 # TODO: Do we need the symbol type after this?
                 sym.type = sym.type.name
 
+    # for all equations in original class
+    for equation in class_.equations:
+        flat_class.equations.append(equation)
+
+        # TODO: Do we still need this?
+        # if isinstance(equation, ast.ConnectClause):
+        #     # following section 9.2 of the Modelica spec, we treat 'inner' and 'outer' connectors differently.
+        #     if not hasattr(equation, "__left_inner"):
+        #         equation.__left_inner = len(equation.left.child) > 0
+        #     if not hasattr(equation, "__right_inner"):
+        #         equation.__right_inner = len(equation.right.child) > 0
+
     return flat_class
 
 

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -225,6 +225,9 @@ class TreeWalker:
             )
             or (isinstance(tree, ast.Symbol) and child_name == "_parent")
             or (isinstance(tree, SymbolReference) and child_name == "scope")
+            # HACK: We do this to avoid looping over `imports` again in referenced functions.
+            # Feels a bit ugly though.
+            or (isinstance(tree, SymbolReference) and child_name == "symbol" and tree.symbol.type == "function")
         ):
             return True
         return False
@@ -1294,6 +1297,8 @@ def flatten(root: ast.Tree, class_name: ast.ComponentRef) -> ast.Class:
     # pull functions to the top level,
     # putting them prior to the model class so that they are visited
     # first by the tree walker.
+
+    # TODO: I don't know if this is needed/wanted anymore
     functions_and_classes = flat_class.functions
     flat_class.functions = OrderedDict()
     functions_and_classes.update(root.classes)

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -14,7 +14,7 @@ import casadi as ca
 import numpy as np
 
 import pymoca.backends.casadi.generator as gen_casadi
-from pymoca import parser
+from pymoca import parser, ast, tree
 from pymoca.backends.casadi.alias_relation import AliasRelation
 from pymoca.backends.casadi.api import CachedModel, transfer_model
 from pymoca.backends.casadi.model import (

--- a/test/models/DelayForLoop.mo
+++ b/test/models/DelayForLoop.mo
@@ -1,5 +1,20 @@
+// Test whether we properly
+// - for i in 2:i <-- the last i is not the same as the first i
+// - i in nested for loop in ForIndex _is_ that of the inner scope, e.g. for j in 1:i
+// - We can apparently just redeclare builtin symbols/references like "sin", whatever we do take precedence
+
+// TODO: We cannot define "cos" / "sin" etc at the _top_ level. Can we add a check for that? Or generally just
+// add those symbols/functions to the root level of the tree from the get-go, and have the "already defined" check be more generic.
+
 model DelayForLoop
-  constant Integer other = 3;
+  function cos
+    input Real x;
+    output Real y;
+  algorithm
+    y := 2 * x;
+  end cos;
+
+  constant Integer sin = 3;
   constant Integer i = 3;
   constant Integer j = 3;
   Real[3] x, y, a;
@@ -7,12 +22,11 @@ model DelayForLoop
   parameter Real delay_time(fixed=true);
   parameter Real eps;
 equation
-  for i in 2:j loop
-    x[i] = 5 * z[i] * eps;
-    y[i] = delay(3 * a[i] * eps, delay_time);
-    for j in i:3 loop
-      a[i] = i * j;
+  for sin in 2:sin loop
+    x[sin] = 5 * z[sin] * eps;
+    y[sin] = delay(3 * a[sin] * eps, delay_time);
+    for j in sin:3 loop
+      a[sin] = sin * cos(j);
     end for;
   end for;
-  // a = x;
 end DelayForLoop;

--- a/test/models/DelayForLoop.mo
+++ b/test/models/DelayForLoop.mo
@@ -1,9 +1,10 @@
 model DelayForLoop
-  Real[3] x, y, a;
+  Real[3] x, y, a, i;
   input Real z[3];
-  input Real delay_time(fixed=true);
+  parameter Real delay_time(fixed=true);
   parameter Real eps;
 equation
+  i = x .* a;
   for i in 2:3 loop
     x[i] = 5 * z[i] * eps;
     y[i] = delay(3 * a[i] * eps, delay_time);

--- a/test/models/DelayForLoop.mo
+++ b/test/models/DelayForLoop.mo
@@ -1,13 +1,18 @@
 model DelayForLoop
-  Real[3] x, y, a, i;
+  constant Integer other = 3;
+  constant Integer i = 3;
+  constant Integer j = 3;
+  Real[3] x, y, a;
   input Real z[3];
   parameter Real delay_time(fixed=true);
   parameter Real eps;
 equation
-  i = x .* a;
-  for i in 2:3 loop
+  for i in 2:j loop
     x[i] = 5 * z[i] * eps;
     y[i] = delay(3 * a[i] * eps, delay_time);
+    for j in i:3 loop
+      a[i] = i * j;
+    end for;
   end for;
-  a = x;
+  // a = x;
 end DelayForLoop;

--- a/test/models/ExtendsOrder.mo
+++ b/test/models/ExtendsOrder.mo
@@ -23,15 +23,25 @@ package P
     model B
       model BT
         Real x;
-        parameter Real bla = 100;
-        parameter Real m(nominal=bla, min=P.min_m, max=max_m) = 0;
+        constant Real bla = 100;
+        // Are there references in which the scope remains BT, not bt?
+        parameter Real m(nominal=BT.bla, min=P.min_m, max=2 * max_m) = 0;
+        parameter Real n(nominal=bla, min=P.min_m, max=2 * max_m) = 0;
       equation
-        x = m;
+        x = m * max_m;
       end BT;
-      BT bt;
+      BT bt(bla=150);
     end B;
 
     extends A(redeclare model AT = BT); // Here we expect to find P.M.B.BT, not P.BT
-    extends B;
+    extends B(BT(bla=200));
   end M;
 end P;
+
+
+// - Scope back to None?
+// - New testcase of this ExtendsOrder... not sure if we have something that covers this weird scoping I do now with bla
+// - find_symbol can be unified with find_constant_symbol. Finding symbols _outside_ the current class is
+//   only allowed for constants, not for other types. Raise Exception if "symbol found, but not constant" just like Openmodelica.
+// - Testcase for the above? I.e. symbol found but not constant
+// - Can you have constants that are not elementary? I.e. ones that have a type that is a class?

--- a/test/models/ExtendsOrder.mo
+++ b/test/models/ExtendsOrder.mo
@@ -1,5 +1,7 @@
 // Taken from https://trac.modelica.org/Modelica/ticket/1829#comment:38
 package P
+  constant Real max_m = 1000;
+  constant Real min_m = 1.0;
   model BT
     parameter Real m = -1;
       Real x;
@@ -21,7 +23,8 @@ package P
     model B
       model BT
         Real x;
-        parameter Real m = 0;
+        parameter Real bla = 100;
+        parameter Real m(nominal=bla, min=P.min_m, max=max_m) = 0;
       equation
         x = m;
       end BT;

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -718,41 +718,6 @@ class ParseTest(unittest.TestCase):
         """Test constant references in non-elementary typed equations"""
         txt = """
             package Package
-                type Length = Real;
-                // Make sure this value is different from the
-                // one in Model, so we can make sure the correct one
-                // is referred to and flattened.
-                constant Real KM_TO_M = 900.0;
-            end Package;
-
-            model Model
-                constant Real KM_TO_M = 1000.0;
-                Package.Length distance_km = 1.0;
-                Package.Length distance_m = Package.KM_TO_M * distance_km;
-            end Model;
-        """
-
-        ast_tree = parser.parse(txt)
-        class_name = "Model"
-        comp_ref = ast.ComponentRef.from_string(class_name)
-        flat_tree = tree.flatten(ast_tree, comp_ref)
-
-        # Check that the constant symbol is in the flattened class, has the correct value, and is
-        # also referenced to in the flattened set of equations.
-        self.assertIn("Package.KM_TO_M", flat_tree.classes[class_name].symbols.keys())
-        self.assertEqual(
-            flat_tree.classes[class_name].symbols["Package.KM_TO_M"].value.value, 900.0
-        )
-        self.assertIsNone(flat_tree.classes[class_name].symbols["distance_m"].value.value)
-        self.assertSetEqual(
-            {"distance_km", "Package.KM_TO_M"},
-            {x.name for x in flat_tree.classes[class_name].equations[1].right.operands},
-        )
-
-    def test_constant_reference_type_equation(self):
-        """Test constant references in non-elementary typed equations"""
-        txt = """
-            package Package
               type Length = Real;
               constant Real KM_TO_M = 900.0;
             end Package;

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -713,6 +713,41 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(flat_tree.classes[class_name].equations[0].left.name, "d.c.y")
         self.assertEqual(flat_tree.classes[class_name].equations[0].right.value, 4)
 
+    def test_constant_reference_type_equation(self):
+        """Test constant references in non-elementary typed equations"""
+        txt = """
+            package Package
+                type Length = Real;
+                // Make sure this value is different from the
+                // one in Model, so we can make sure the correct one
+                // is referred to and flattened.
+                constant Real KM_TO_M = 900.0;
+            end Package;
+
+            model Model
+                constant Real KM_TO_M = 1000.0;
+                Package.Length distance_km = 1.0;
+                Package.Length distance_m = Package.KM_TO_M * distance_km;
+            end Model;
+        """
+
+        ast_tree = parser.parse(txt)
+        class_name = "Model"
+        comp_ref = ast.ComponentRef.from_string(class_name)
+        flat_tree = tree.flatten(ast_tree, comp_ref)
+
+        # Check that the constant symbol is in the flattened class, has the correct value, and is
+        # also referenced to in the flattened set of equations.
+        self.assertIn("Package.KM_TO_M", flat_tree.classes[class_name].symbols.keys())
+        self.assertEqual(
+            flat_tree.classes[class_name].symbols["Package.KM_TO_M"].value.value, 900.0
+        )
+        self.assertIsNone(flat_tree.classes[class_name].symbols["distance_m"].value.value)
+        self.assertSetEqual(
+            {"distance_km", "Package.KM_TO_M"},
+            {x.name for x in flat_tree.classes[class_name].equations[1].right.operands},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -847,6 +847,27 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(flat_tree.classes[class_name].equations[0].left.name, "d.c.y")
         self.assertEqual(flat_tree.classes[class_name].equations[0].right.value, 4)
 
+    def test_inheritance_resistor(self):
+        with open(os.path.join(MODEL_DIR, "InheritanceInstantiationResistor.mo"), "r") as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef.from_string("P.M"))
+
+        self.assertEqual(flat_tree.classes["P.M"].symbols["p.v"].nominal.value, 0.0)
+        self.assertEqual(flat_tree.classes["P.M"].symbols["p.v"].max.value, 10.0)
+        self.assertEqual(flat_tree.classes["P.M"].symbols["n.v"].nominal.value, 0.0)
+        self.assertEqual(flat_tree.classes["P.M"].symbols["n.v"].max.value, 10.0)
+
+    def test_inheritance_instantiation(self):
+        with open(os.path.join(MODEL_DIR, "RecursiveInstantiation.mo"), "r") as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef.from_string("M"))
+
+        self.assertEqual(flat_tree.classes["M"].symbols["b.a.e"].type.name, "Real")
+        self.assertEqual(flat_tree.classes["M"].symbols["b.a.p"].type.name, "Integer")
+        self.assertEqual(flat_tree.classes["M"].symbols["b.a.p"].value.value, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
For the added test case (see the diff), what was happening is that we added the resolved constant to the wrong class. We added it to the Package.Length class, i.e. the InstanceClass of the type of `distance_m`. Basically what was happening in the example was

1. Entering Model
2. Entering Length
3. Finding reference to constant, changing reference and storing new constant symbol
4. Exiting Length - popping off the stored constant symbols
5. Exiting Model

The reason for this happening was that it was not envisioned at the time of the offending code that we would be entering InstanceClasses other than those part of the lookup tree hierarchy.

Instead, we want to add the stored constant symbols to `Model`. So what we currently implement for the last two steps above is:

4. Exiting Length - skipping popping
5. Exiting Model - popping off the stored constant symbols

Closes #301


Things to test:
- [ ] Extends a redeclared class. E.g. the AT = BT, but then somehow extending from AT. We do a find_class with copy now in `flatten_extends`, but maybe shouldn't then?

Things for future:
- [ ] Would be really awesome if we could just compare output / trees with `omc -i=...` (or reference flattened case)
- [ ] Would be nice if we can handle the `assert(Util.compareReal ...)` stuff like in ImportScopeType . Then we can just use the already existing .mo files in the modelica test library as test cases.