### PR TITLE
CI/CD: Update max Python to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: pre-commit/action@v3.0.0
 
   test:
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.10", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
         submodules: true
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - run: |
         python -m pip install --upgrade pip
         pip install tox
@@ -72,7 +72,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,9 @@ classifiers = [
 homepage = "https://github.com/pymoca/pymoca"
 
 [project.optional-dependencies]
-casadi = ["casadi>=3.4.0"]
+# Note that we need setuptools for the distutils.ccompiler dependency
+# in the CasADi backend.
+casadi = ["casadi>=3.4.0", "setuptools>=60.0.0"]
 lxml = ["lxml>=3.5.0", "scipy>=0.13.3"]
 sympy = ["sympy>=0.7.6.1", "scipy>=0.13.3", "jinja2>=2.10.1"]
 examples = ["jupyterlab", "matplotlib"]


### PR DESCRIPTION
Try Python 3.12 in the test matrix.

Also since there are so many versions of Python active (3.8 to 3.12), it seems excessive to test every version. This changes the matrix to just three versions: 3.8, 3.10, 3.12. For future updates, I envision picking min, max, and median of the supported Python versions.