### PR TITLE
CI/CD: Fix cache test

### DIFF
--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -785,8 +785,14 @@ class ParseTest(unittest.TestCase):
             cursor.execute("SELECT COUNT(*) FROM models")
             self.assertEqual(cursor.fetchone()[0], 1)
 
-            # Parse again to update the cache hit time
-            _ = parser.parse(txt, model_cache_folder=Path(tmpdirname), always_update_last_hit=True)
+            # Check that we get log messages saying the cache entry was found
+            # We also force an update to the cache hit time
+            logger = logging.getLogger("pymoca")
+            with self.assertLogs(logger, level="DEBUG") as cm:
+                _ = parser.parse(
+                    txt, model_cache_folder=Path(tmpdirname), always_update_last_hit=True
+                )
+                self.assertIn(") found in cache", cm.output[0])
 
             cursor.execute("SELECT value FROM metadata WHERE key='created_at'")
             second_created_at = int(cursor.fetchone()[0])

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -785,6 +785,11 @@ class ParseTest(unittest.TestCase):
             cursor.execute("SELECT COUNT(*) FROM models")
             self.assertEqual(cursor.fetchone()[0], 1)
 
+            # We close and later re-open to make sure that we do not read
+            # stale data from the database file when running on e.g. NFS.
+            cursor.close()
+            conn.close()
+
             # Check that we get log messages saying the cache entry was found
             # We also force an update to the cache hit time
             logger = logging.getLogger("pymoca")
@@ -793,6 +798,9 @@ class ParseTest(unittest.TestCase):
                     txt, model_cache_folder=Path(tmpdirname), always_update_last_hit=True
                 )
                 self.assertIn(") found in cache", cm.output[0])
+
+            conn = sqlite3.connect(full_db_path)
+            cursor = conn.cursor()
 
             cursor.execute("SELECT value FROM metadata WHERE key='created_at'")
             second_created_at = int(cursor.fetchone()[0])


### PR DESCRIPTION
When running on Github Actions, the first and second hit time have a tendency to be equal, possibly for reasons related to mounted/network storage.

To make sure that the cache is hit, we can also check whether the log messages indicate as such, instead of just looking at a forced update of the last hit time.

Note that this commit does not fix the failing of the test, it just adds an additional check to better understand what is going on.