### PR TITLE
Fix Windows runs on Github Actions

### DIFF
--- a/src/pymoca/parser.py
+++ b/src/pymoca/parser.py
@@ -1037,8 +1037,11 @@ def parse(
             (datetime.utcnow() - timedelta(days=cache_expiration_days)).timestamp() * 1e6
         )
         cursor.execute("DELETE FROM models WHERE last_hit < ?", (cutoff_time,))
+        # Sometimes Windows time resolution is a bit coarse, so we make
+        # sure that if we update the last_prune time, it is actually newer
+        # than the previous one.
         cursor.execute(
-            "UPDATE metadata SET value = ? WHERE key = ?",
+            "UPDATE metadata SET value = max(value + 1, ?) WHERE key = ?",
             (_microseconds_since_epoch(), "last_prune"),
         )
 
@@ -1070,8 +1073,12 @@ def parse(
 
         if always_update_last_hit or last_hit < yesterday:
             cursor.execute("BEGIN TRANSACTION;")
+            # Sometimes Windows time resolution is a bit coarse, so we make
+            # sure that if we update the last_hit time, it is actually newer
+            # than the previous one.
             cursor.execute(
-                "UPDATE models SET last_hit = ? WHERE txt_hash = ? AND pymoca_version = ?",
+                "UPDATE models SET last_hit = max(last_hit + 1, ?) WHERE txt_hash = ? "
+                "AND pymoca_version = ?",
                 (_microseconds_since_epoch(), txt_hash, pymoca_version),
             )
             conn.commit()

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -785,11 +785,6 @@ class ParseTest(unittest.TestCase):
             cursor.execute("SELECT COUNT(*) FROM models")
             self.assertEqual(cursor.fetchone()[0], 1)
 
-            # We close and later re-open to make sure that we do not read
-            # stale data from the database file when running on e.g. NFS.
-            cursor.close()
-            conn.close()
-
             # Check that we get log messages saying the cache entry was found
             # We also force an update to the cache hit time
             logger = logging.getLogger("pymoca")
@@ -798,9 +793,6 @@ class ParseTest(unittest.TestCase):
                     txt, model_cache_folder=Path(tmpdirname), always_update_last_hit=True
                 )
                 self.assertIn(") found in cache", cm.output[0])
-
-            conn = sqlite3.connect(full_db_path)
-            cursor = conn.cursor()
 
             cursor.execute("SELECT value FROM metadata WHERE key='created_at'")
             second_created_at = int(cursor.fetchone()[0])


### PR DESCRIPTION
- [x] ~~It should not just be the `test_parse_cache_hit` test failing. It might be the _first_ to fail, but if we fix that one, I'd expect `test_parse_cache_purge` to fail.~~ The former is much quicker to do a second call compared to the latter (which reimports a module, so effective sleep)
- [x] Every hour or so, push two commits that undo and redo the sleep. Maybe alternating (00:00, 02:00,... ) we undo, and (01:00, ..) we redo. Do this for like a week or so to get some statistics.

Testing over in https://github.com/jackvreeken/pymoca-test-1 and https://github.com/jackvreeken/pymoca-test-2.

Current commit of this PR has been stress tested in https://github.com/jackvreeken/pymoca-test-2 for the last 12 hours (and will keep on running).