### PR TITLE
CasADi backend:  Special-case binary operations on elements with numel = 0

### DIFF
--- a/src/pymoca/backends/casadi/generator.py
+++ b/src/pymoca/backends/casadi/generator.py
@@ -375,7 +375,11 @@ class Generator(TreeListener):
             lhs = ca.MX(self.get_mx(tree.operands[0]))
             rhs = ca.MX(self.get_mx(tree.operands[1]))
             lhs_op = getattr(lhs, OP_MAP[op])
-            src = lhs_op(rhs)
+            if lhs.numel() == 0 and rhs.numel() == 0:
+                # Handle operations on 0x1 and 0x0 vectors
+                src = ca.MX()
+            else:
+                src = lhs_op(rhs)
         elif op in OP_MAP and n_operands == 1:
             lhs = ca.MX(self.get_mx(tree.operands[0]))
             lhs_op = getattr(lhs, OP_MAP[op])
@@ -449,7 +453,11 @@ class Generator(TreeListener):
         if src_left.shape != src_right.shape and src_left.shape == src_right.shape[::-1]:
             src_right = ca.transpose(src_right)
 
-        self.src[tree] = src_left - src_right
+        if src_left.numel() == 0 and src_right.numel() == 0:
+            # Handle operations on 0x1 and 0x0 vectors
+            self.src[tree] = ca.MX()
+        else:
+            self.src[tree] = src_left - src_right
 
     def enterForEquation(self, tree):
         logger.debug("enterForEquation")

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -3056,6 +3056,13 @@ class GenCasadiTest(unittest.TestCase):
 
         self.assert_model_equivalent(ref_model, casadi_model)
 
+    def test_zero_vector(self):
+        with open(os.path.join(MODEL_DIR, "ZeroVector.mo"), "r") as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+        casadi_model = gen_casadi.generate(ast_tree, "ZeroVector")
+        self.assertEqual(len(casadi_model.dae_residual_function.mx_out()), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/models/ZeroVector.mo
+++ b/test/models/ZeroVector.mo
@@ -1,0 +1,7 @@
+model ZeroVector
+  Real x[0];
+  Real y[0];
+  Real z[0];
+equation
+  x = y .* z;
+end ZeroVector;


### PR DESCRIPTION
Since CasADi 3.6, two matrices with zero elements, but with different dimensions (i.e., 0x1, 1x0, or 0x0), can no longer be added or subtracted. This change checks for lhs and rhs having zero elements before adding or subtracting in CasADi.