### PR TITLE
Keep track of the depth at which a symbol is nested in arrays

### DIFF
--- a/src/pymoca/ast.py
+++ b/src/pymoca/ast.py
@@ -426,6 +426,7 @@ class Symbol(Node):
         self.dimensions = [
             [Primary(value=None)]
         ]  # type: List[List[Union[Expression, Primary, ComponentRef]]]
+        self.array_depth = 0
         self.comment = ""  # type: str
         self.start = Primary(value=None)  # type: Union[Expression, Primary, ComponentRef, Array]
         self.min = Primary(value=None)  # type: Union[Expression, Primary, ComponentRef, Array]

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -631,6 +631,10 @@ def flatten_symbols(class_: ast.InstanceClass, instance_name="") -> ast.Class:
             for flat_class_symbol in flat_sub_class.symbols.values():
                 flat_class_symbol.dimensions = flat_sym.dimensions + flat_class_symbol.dimensions
 
+                # Keep track of how deeply a symbol is nested in arrays
+                flat_class_symbol.array_depth += sum(
+                    [not (isinstance(dim, ast.Primary) and dim.value == None) for dims in flat_sym.dimensions for dim in dims])
+
             # add sub_class members symbols and equations
             flat_class.classes.update(flat_sub_class.classes)
             flat_class.symbols.update(flat_sub_class.symbols)


### PR DESCRIPTION
The sum() operator acts along the "most nested" dimension.  To make sure this maps to the correct CasADi operation, we must keep track of how deeply a symbol has been nested in arrays.