### PR TITLE
Fixes for 0.9.1 -> 0.9.2 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 # pylint: disable=no-init, too-few-public-methods
 
 
-PYTHON_VERSION = '.'.join([str(i) for i in sys.version_info[:3]])
-PYTHON_VERSION_REQUIRED = '3.5.0'
+PYTHON_VERSION = sys.version_info[:3]
+PYTHON_VERSION_REQUIRED = (3, 5, 0)
 if PYTHON_VERSION < PYTHON_VERSION_REQUIRED:
     sys.exit("Sorry, only Python >= {:s} is supported".format(
         PYTHON_VERSION_REQUIRED))


### PR DESCRIPTION
A string comparison for versions would result in "3.10.0" being smaller than "3.5.0" (because 3.1 is smaller than 3.5). We should just do a tuple comparison.