### PR TITLE
Control 0 10 0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ homepage = "https://github.com/pymoca/pymoca"
 casadi = ["casadi>=3.4.0", "setuptools>=60.0.0"]
 lxml = ["lxml>=3.5.0", "scipy>=0.13.3"]
 sympy = ["sympy>=0.7.6.1", "scipy>=0.13.3", "jinja2>=2.10.1"]
-examples = ["jupyterlab", "matplotlib"]
+examples = ["jupyterlab", "matplotlib", "control==0.10.0"]
 all = ["pymoca[casadi,lxml,sympy,examples]"]
 
 # See the docstring in versioneer.py for instructions. Note that after changing

--- a/test/notebooks/Spring.ipynb
+++ b/test/notebooks/Spring.ipynb
@@ -1262,7 +1262,7 @@
     }
    ],
    "source": [
-    "control.rlocus(ss[0,0], klist=pl.logspace(-2,1,1000));\n",
+    "control.rlocus(ss[0,0], kvect=pl.logspace(-2,1,1000));\n",
     "pl.grid()"
    ]
   },


### PR DESCRIPTION
This replaces #327 as a fix for #324,

* adding the missing optional `[examples]` dependency on `control==0.10.0`
  * pinning the version because of the as-yet unreleased upstream change in [a9415a0](https://github.com/python-control/python-control/commit/a9415a036d4e34d18446d6cf3c3fda093859736d) (2024-04-04)
  * though that will still have a [graceful deprecation](https://github.com/python-control/python-control/blob/2d1f514d5b56b07877a879517e828d965777c5f8/control/rlocus.py#L163)
* calling `control.rlocus` from here with `kvect`
  * rather than previous `klist` because that doesn't work in `control 0.10.0` or
  * the future `gains` because that isn't yet available in `control 0.10.0`

```python
import control
import pymoca.parser
import pymoca.backends.sympy.generator as generator

# modelica_src = '''...'''
ast = pymoca.parser.parse(modelica_src)
src_code = generator.generate(ast, 'System')
exec(src_code)
model = System()
ss = control.ss(*model.linearize())
control.rlocus(ss[0,0], klist=pl.logspace(-2,1,1000));
```

raises

> TypeError: unrecognized keywords: {'klist': array([ 0.01      ,  0.01006939,  0.01013925,  0.01020961,  0.01028045,  

so `klist` is no good, but neither is `gains` (as in #327) for now; it raises exactly the same `TypeError`.
