### PR TITLE
Fix installation regression on Python 3.8 / 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ homepage = "https://github.com/pymoca/pymoca"
 casadi = ["casadi>=3.4.0", "setuptools>=60.0.0"]
 lxml = ["lxml>=3.5.0", "scipy>=0.13.3"]
 sympy = ["sympy>=0.7.6.1", "scipy>=0.13.3", "jinja2>=2.10.1"]
-examples = ["jupyterlab", "matplotlib", "control==0.10.0"]
+examples = ["jupyterlab", "matplotlib", "control>=0.9.3.post2,<=0.10.0"]
 all = ["pymoca[casadi,lxml,sympy,examples]"]
 
 # See the docstring in versioneer.py for instructions. Note that after changing


### PR DESCRIPTION
The `control` package version 0.10.0 we pinned in 0902b78 is only available for Python 3.10 and above. We still want to support Python 3.8 and 3.9, so we extend the range to the latest version of `control` that did so as well.