### PR TITLE
CI/GA: Update actions to their latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 
   test:
     needs: pre-commit
@@ -32,10 +32,10 @@ jobs:
         python-version: ["3.8", "3.10", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - run: |
@@ -49,19 +49,20 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags') }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - run: |
         python -m pip install --upgrade pip
         pip install tox
     - run: tox -e coverage
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy:
     needs: test
@@ -69,8 +70,8 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - run: |
@@ -82,8 +83,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
-    - uses: softprops/action-gh-release@v1
+    - uses: softprops/action-gh-release@v2
       with:
         files: dist/*
         generate_release_notes: true
-


### PR DESCRIPTION
GitHub Actions was giving deprecation warnings about NodeJS 16, and that we should update to NodeJS 20. We therefore update all actions to their latest versions.