### PR TITLE
codegen: Workaround MSVC NaN constantness bug

### DIFF
--- a/src/pymoca/backends/casadi/api.py
+++ b/src/pymoca/backends/casadi/api.py
@@ -145,7 +145,9 @@ def _codegen_model(model_folder: str, f: ca.Function, library_name: str):
         compiler_flags = ["-O2", "-fPIC"]
         linker_flags = ["-fPIC"]
     else:
-        compiler_flags = ["/O2", "/wd4101"]  # Shut up unused local variable warnings.
+        # Shut up unused local variable warnings, and use workaround for
+        # NaN-constantness bug in recent Windows SDK versions.
+        compiler_flags = ["/O2", "/wd4101", "/D_UCRT_NOISY_NAN"]
         linker_flags = ["/DLL"]
 
     # Generate C code


### PR DESCRIPTION
Version 10.0.26100 of the Windows SDK introduced changes to how INFINITY and NAN are defined in `math.h`. This resulted in NAN no longer being a compile-time constant, and codegen'd code failing compilation the most recent `windows-latest` image. The workaround is to define _UCRT_NOISY_NAN, which restores the old behavior.

Closes #338