### PR TITLE
CI/CD: Update Python >=3.9 and <=3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
 
   test:
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.9", "3.11", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
         submodules: true
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - run: |
         python -m pip install --upgrade pip
         pip install tox
@@ -73,7 +73,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
+    rev: 24.10.0
     hooks:
       - id: black
         args: [--check, --diff]
@@ -12,7 +12,7 @@ repos:
         # TODO: Commenting out max supported Python version until we pin it for Pymoca
         # language_version: python3.11
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         additional_dependencies:

--- a/antlr/antlr_build.py
+++ b/antlr/antlr_build.py
@@ -1,4 +1,5 @@
 """Generate parser code from given grammar file"""
+
 import os
 import subprocess
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,22 +5,17 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pymoca"
 dynamic = ["version"]
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 description = "A python/modelica based simulation environment."
 keywords = ["modelica", "simulation", "compiler"]
 readme = "README.md"
-authors = [
-    { name = "Pymoca Contributors" },
-]
+authors = [{ name = "Pymoca Contributors" }]
 maintainers = [
     { name = "Jack Vreeken", email = "jack@vreeken.me" },
     { name = "Kent Rutan", email = "gs1150e@icloud.com" },
 ]
-requires-python = ">=3.8"
-dependencies = [
-    "numpy >= 1.8.2",
-    "antlr4-python3-runtime == 4.13.*",
-]
+requires-python = ">=3.9"
+dependencies = ["numpy >= 1.8.2", "antlr4-python3-runtime == 4.13.*"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
@@ -68,7 +63,7 @@ parentdir_prefix = "pymoca-"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 force-exclude = '''
     (
           src/pymoca/generated

--- a/src/pymoca/backends/xml/analysis.py
+++ b/src/pymoca/backends/xml/analysis.py
@@ -1,6 +1,7 @@
 """
 Analysis routines for simulation output.
 """
+
 import os
 from typing import Dict, List
 

--- a/src/pymoca/backends/xml/model.py
+++ b/src/pymoca/backends/xml/model.py
@@ -1,6 +1,7 @@
 """
 This module contiains various mathematical models for a modelica model.
 """
+
 from typing import Any, Dict, List, Union
 
 import casadi as ca

--- a/src/pymoca/backends/xml/sim_scipy.py
+++ b/src/pymoca/backends/xml/sim_scipy.py
@@ -1,6 +1,7 @@
 """
 Scipy based model simulation.
 """
+
 import time
 from typing import Dict
 

--- a/src/pymoca/tree.py
+++ b/src/pymoca/tree.py
@@ -334,9 +334,9 @@ def flatten_extends(
                 extended_orig_class.modification_environment.arguments
             )
         else:
-            extended_orig_class.symbols[
-                "__value"
-            ].class_modification = extended_orig_class.modification_environment
+            extended_orig_class.symbols["__value"].class_modification = (
+                extended_orig_class.modification_environment
+            )
 
         extended_orig_class.modification_environment = ast.ClassModification()
 
@@ -1138,9 +1138,11 @@ def expand_connectors(node: ast.Class) -> None:
                 operands = [op_spec[0] for op_spec in operand_specs]
             else:
                 operands = [
-                    op_spec[0]
-                    if op_spec[1]
-                    else ast.Expression(operator="-", operands=[op_spec[0]])
+                    (
+                        op_spec[0]
+                        if op_spec[1]
+                        else ast.Expression(operator="-", operands=[op_spec[0]])
+                    )
                     for op_spec in operand_specs
                 ]
             expr = operands[-1]


### PR DESCRIPTION
Tests that ran OK 2 days ago are now failing on Python 3.8 on Windows when there have been no changes to tested code. Since Python 3.8 is end of life, let's bump min Python to 3.9 and max to 3.13 and see how it tests out.