### PR TITLE
CI/CD: Fix deploy consistent with pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - uses: actions/setup-python@v5
       with:
         python-version: "3.13"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,12 @@ jobs:
         python-version: "3.13"
     - run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*
     - uses: softprops/action-gh-release@v2
       with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include LICENSE
 include README.md
 recursive-include doc *
-recursive-include java *
 include src/pymoca/_version.py
 include src/pymoca/Modelica.g4
 include src/pymoca/backends/xml/ModelicaXML/schemas/*.xsd

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# <img alt="Pymoca" src="branding/icons/pymocalogo.svg" height="60">
-
+# <img alt="Pymoca" src="https://raw.githubusercontent.com/pymoca/pymoca/refs/heads/master/branding/icons/pymocalogo.svg" height="60">
 A Modelica to computer algebra system (CAS) translator written in Python.
 
 [![CI](https://github.com/pymoca/pymoca/workflows/CI/badge.svg)](https://github.com/pymoca/pymoca/actions?query=workflow%3ACI)
@@ -31,7 +30,7 @@ pip install "pymoca[all]"       # All of the above
 
 Pymoca reads and understands Modelica code (`pymoca.parser`) and provides access to an internal representation of the code called an Abstract Syntax Tree or AST (`pymoca.ast`). The AST is further processed to generate output in various formats (`pymoca.backends`). The `pymoca.tree` module provides functionality to transform the AST into a form that can be more easily used by the backends to generate the target output. In particular, `pymoca.tree` provides classes and functions to convert a hierarchical, object-oriented Modelica model of connected components into a "flat" system of equations and associated variables, parameters, and constants. Pymoca error checking is not always complete or easy to understand, so it is better to develop the Modelica code with other tools and then use Pymoca for translation.
 
-The [test suite](test) contains examples showing how to use Pymoca and the subset of Modelica that it currently supports.
+The [test suite](https://github.com/pymoca/pymoca/tree/master/test) contains examples showing how to use Pymoca and the subset of Modelica that it currently supports.
 
 Here is an example using a simple spring and damper model from the test suite:
 
@@ -66,8 +65,8 @@ print(casadi_model)
 
 Some more interesting examples are in Jupyter notebooks:
 
-* [Casadi Example](test/notebooks/Casadi.ipynb)
-* [Sympy Example](test/notebooks/Spring.ipynb)
+* [Casadi Example](https://github.com/pymoca/pymoca/blob/master/test/notebooks/Casadi.ipynb)
+* [Sympy Example](https://github.com/pymoca/pymoca/blob/master/test/notebooks/Spring.ipynb)
 
 ## Roadmap
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pymoca"
 dynamic = ["version"]
 license = { file = "LICENSE" }
-description = "A python/modelica based simulation environment."
+description = "A Modelica to computer algebra system (CAS) translator."
 keywords = ["modelica", "simulation", "compiler"]
 readme = "README.md"
 authors = [{ name = "Pymoca Contributors" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ sympy = ["sympy>=0.7.6.1", "scipy>=0.13.3", "jinja2>=2.10.1"]
 examples = ["jupyterlab", "matplotlib", "control>=0.9.3.post2,<=0.10.0"]
 all = ["pymoca[casadi,lxml,sympy,examples]"]
 
+[tool.setuptools.dynamic]
+version = { attr = "pymoca.__version__" }
+
 # See the docstring in versioneer.py for instructions. Note that after changing
 # this section, run `versioneer install --no-vendor`, commit the results.
 


### PR DESCRIPTION
Change from the old setup.py-based build to something consistent with current Python packaging standards (though the instructions are poorly documented). I guess we have not done a deploy since the change to pyproject.toml, so this is the first time we are seeing the issue.

EDIT: We also fixed some issues with the build and upload to PyPI including the rendering of the README on PyPI.