### PR TITLE
CI/CD: Fix `pymoca.__version__`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,9 @@ sympy = ["sympy>=0.7.6.1", "scipy>=0.13.3", "jinja2>=2.10.1"]
 examples = ["jupyterlab", "matplotlib", "control>=0.9.3.post2,<=0.10.0"]
 all = ["pymoca[casadi,lxml,sympy,examples]"]
 
-[tool.setuptools.dynamic]
-version = { attr = "pymoca.__version__" }
+# TODO: Uncomment this when moving away from versioneer.
+# [tool.setuptools.dynamic]
+# version = { attr = "pymoca.__version__" }
 
 # See the docstring in versioneer.py for instructions. Note that after changing
 # this section, run `versioneer install --no-vendor`, commit the results.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+"""Minimal setup file for versioneer."""
+
+from setuptools import setup
+
+import versioneer
+
+setup(
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+)


### PR DESCRIPTION
We are currently getting "0+unknown" from the PyPI package. Also, we are getting the setuptools-generated version number in development mode (no "dirty" flag currently needed for the parse cache code).

This fixes it by adding setup.py back in to generate _version.py and removes the setuptools dynamic versioning from pyproject.toml so that we get the version number from versioneer for both the build artifacts and _version.py.