### PR TITLE
sympy: Fix runtime integrated function shape

### DIFF
--- a/src/pymoca/backends/sympy/runtime.py
+++ b/src/pymoca/backends/sympy/runtime.py
@@ -112,7 +112,7 @@ class OdeModel:
         ss_subs.update(self.c0)
 
         # create f (dynamics) lambda function
-        f_lam = sympy.lambdify((self.t, x_sym, u_sym), self.f.subs(ss_subs))
+        f_lam = sympy.lambdify((self.t, x_sym, u_sym), sympy.flatten(self.f.subs(ss_subs)))
         res = np.array(f_lam(0, np.zeros(len(self.x)), np.zeros(len(self.u))), dtype=float)
         if len(res) != len(self.x):
             raise IOError("f doesn't return correct size", res, self.x)


### PR DESCRIPTION
Change the shape of the array that the function to integrate returns from (n,1) to a flat (n,) shape so that it is compatible with `scipy.integrate.ode`.

There was a change in SciPy 1.17.0 that caused all the sympy tests to fail. There were two changes to integration in that version, one or both of which likely caused the issue.

Closes #351 