### PR TITLE
Add release notes and packaging testability

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+# Configuration for GitHub's automatically generated release notes.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Merged PRs are sorted into the sections below by their labels. A PR lands in
+# the first category whose labels it matches, so order matters. The final
+# "Other Changes" catch-all ("*") ensures an unlabeled PR is still listed.
+changelog:
+  exclude:
+    labels:
+      - ignore
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Performance
+      labels:
+        - performance
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
     # Every Wednesday at 6:06 UTC
     - cron: "6 6 * * 3"
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -85,7 +88,7 @@ jobs:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  deploy:
+  build:
     needs: test
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
@@ -99,14 +102,105 @@ jobs:
           python-version: "3.14"
       - run: |
           python -m pip install --upgrade pip
-          pip install build twine
-      - env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          pip install build
+      - run: python -m build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/*
+
+  # Gate for both deploy jobs, so a tag with no release notes fails before
+  # anything is published. Independent of the test matrix to report early.
+  changelog:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: CHANGELOG.md
+          sparse-checkout-cone-mode: false
+      # Reject tags that aren't PEP 440 canonical (X.Y.Z, X.Y.Z.devN,
+      # X.Y.ZrcN) so a non-canonical tag fails clearly here instead of
+      # silently taking a different PyPI version than the tag.
+      - name: Validate tag format
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          python -m build
-          twine upload dist/*
+          if ! [[ "$REF_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+|rc[0-9]+)?$ ]]; then
+            echo "::error::Tag '$REF_NAME' is not PEP 440 canonical: use X.Y.Z, X.Y.Z.devN, or X.Y.ZrcN"
+            exit 1
+          fi
+      # The section runs from its "## <version>" heading to the next "## "
+      # heading.
+      - name: Extract release summary from CHANGELOG
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # A dev or rc tag checks the section for the release it leads up to.
+          version="${REF_NAME%%.dev*}"
+          version="${version%%rc*}"
+          awk -v ver="$version" '
+            !found && index($0, "## " ver) == 1 && substr($0, length(ver) + 4, 1) ~ /^ *$/ {
+              found = 1
+              next
+            }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > release-summary.md
+          if [ ! -s release-summary.md ]; then
+            echo "::error file=CHANGELOG.md::No release notes section for $version"
+            exit 1
+          fi
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-summary
+          path: release-summary.md
+
+  testpypi-deploy:
+    needs: [build, changelog]
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.ref_name, '.dev') }}
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pymoca
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  deploy:
+    needs: [build, changelog]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '.dev') }}
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pymoca
+    permissions:
+      id-token: write # PyPI trusted publishing
+      contents: write # Create the GitHub release
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-summary
+      - uses: pypa/gh-action-pypi-publish@release/v1
       - uses: softprops/action-gh-release@v3
         with:
           files: dist/*
+          # Auto-generated PR/commit list, appended to the CHANGELOG summary.
           generate_release_notes: true
+          body_path: release-summary.md
+          # Keep a release candidate from displacing the latest stable release.
+          prerelease: ${{ contains(github.ref_name, 'rc') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+This is a summary of user-facing changes in each pymoca release version.
+For full release notes including change details, see the
+[Pymoca release list on GitHub](https://github.com/pymoca/pymoca/releases/).
+
+<!-- When tagging a release, add a section with the heading `## <version>`
+and a summary of the user-facing changes. See the existing entries.
+
+The changelog job in `.github/workflows/ci.yml` extracts the section matching
+the pushed tag, and the deploy job uses it as the release summary on GitHub,
+above the auto-generated pull request list.
+
+A tag with no section here fails before anything is published. A `.devN` or
+`rcN` tag checks the section for the release it leads up to, so `0.12.0.dev1`
+or `0.12.0rc1` needs a `## 0.12.0` heading.
+-->
+
+## 0.12.0
+
+Pymoca now contains a complete rewrite of flattening based on the Modelica Language Specification v3.5, tested against 645 example models in Modelica Standard Library 4.0.x. 577 of them (about 90%) flatten without error. Every remaining failure is one of two unimplemented features, `ExternalObject` and stream connectors. Getting those models through the backends is separate work still in progress.
+
+Pymoca also now resolves top-level names over MODELICAPATH, following the ordered first-wins precedence of MLS section 13.3.
+
+A `pymoca` script is installed into your PATH with the PyPI install. Run `pymoca --help` to see how to use it.
+
+This release makes some minor breaking API changes for pymoca 0.11 users, including a `tree.flatten_class()` that is a different function than the 0.11 helper of the same name. See [doc/index.md](https://github.com/pymoca/pymoca/blob/a12e8813eed8caa66e12d59e26c348bc6035dbea/doc/index.md) for a list of differences with pymoca 0.11 and links to documentation on installation, usage, examples, and the new flattening architecture which includes a list of yet unimplemented Modelica features. Python 3.10+ is now required. The ModelicaXML backend is unmaintained and may be removed in a future release.
+
+## Earlier Versions
+
+See [GitHub Releases](https://github.com/pymoca/pymoca/releases).

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2021, James Goppert and the Pymoca contributors.
+Copyright (c) 2016, James Goppert and the Pymoca contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include CHANGELOG.md
 recursive-include doc *
 include src/pymoca/_version.py
 include src/pymoca/Modelica.g4


### PR DESCRIPTION
For the upcoming release with a lot of new content, it would be good to add a summary to help understand the major user-facing improvements. At this stage of Pymoca's maturity, it would be also be good to keep maintenance lightweight and forgiving for maintainers. 

This adds a `CHANGELOG.md` file, but only containing the summary for each release and a link to GitHub if you want more detail. Upon push of a release tag, release notes are automatically assembled by the GitHub CI workflow `changelog` job with the summary for the release extracted from `CHANGELOG.md` followed by a categorized list of pull requests and a link to all the commits. The workflow will error out before any PyPI upload if the summary is not there for the given tag version.

Release tags ending in .dev* result in an upload to TestPyPI. Tags ending in rc* (non-dotted per PEP 440) are uploaded to PyPI, but are marked pre-release so they don't replace the current production release. These two options allow for testing of the packaging before official release. As before, bare version tags are uploaded to PyPI as a production release.

Along with the CI/CD updates above, we also upgrade security to using PyPI Trusted Publishing (OpenID Connect) with `pypa/gh-action-pypi-publish` instead of twine with credentials.

Finally, in the spirit of keeping maintenance lean, I noticed that the copyright end year was stale in the `LICENSE` file and changed it to just be the initial commit year, following the BSD license convention, to remove the need for future maintenance.

EDIT: Updated to PEP 440 compliant versioning per review comments.